### PR TITLE
Handle esr scheme

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -34,6 +34,16 @@
 				<string>earth.hypha.wallet.hyphaWallet</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>esr</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>esr</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>


### PR DESCRIPTION
iOS handles esr:// scheme

Testing: 

Push esr:// URL onto Safari browser - paste & go - it will open the wallet.

example URL

```
esr://gmNgYmBYlmzC9MoglIFhB9frlxK9jIwMEMAEpQVhAhwW5sZG5mZmZowJGSUlBVb6-okFmboFiZW5qXklehmVBRmJeqmJRSUZ-iVFiXnFicklmfl59qWZKbZJRinGFsmWqbqW5iZpuqYmZga6lhaWibpG5uYW5uaGBhYmiUlqJRXxQKXV1SUVtbUMAA
```

