### PR TITLE
Fix sign transaction

### DIFF
--- a/lib/core/network/api/endpoints.dart
+++ b/lib/core/network/api/endpoints.dart
@@ -2,7 +2,7 @@ class Endpoints {
   Endpoints._();
 
   // base url
-  static const String baseUrl = 'http://telos.greymass.com';
+  static const String baseUrl = 'http://mainnet.telos.net';
 
   // receiveTimeout
   static const int receiveTimeout = 15000;

--- a/lib/core/network/api/endpoints.dart
+++ b/lib/core/network/api/endpoints.dart
@@ -2,7 +2,7 @@ class Endpoints {
   Endpoints._();
 
   // base url
-  static const String baseUrl = 'http://eos.greymass.com';
+  static const String baseUrl = 'http://telos.greymass.com';
 
   // receiveTimeout
   static const int receiveTimeout = 15000;

--- a/lib/core/network/api/eos_service.dart
+++ b/lib/core/network/api/eos_service.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 
 import 'package:async/async.dart';
+import 'package:dio/dio.dart' as dio;
 import 'package:hypha_wallet/core/crypto/eosdart/eosdart.dart';
 import 'package:hypha_wallet/core/crypto/seeds_esr/eos_transaction.dart';
-import 'package:hypha_wallet/core/local/models/user_auth_data.dart';
-import 'package:hypha_wallet/core/local/services/secure_storage_service.dart';
 import 'package:hypha_wallet/core/logging/log_helper.dart';
 
 String onboardingPrivateKey = '5JhM4vypLzLdDtHo67TR5RtmsYm2mr8F2ugqcrCzfrMPLvo8cQW';
@@ -38,32 +37,30 @@ class EOSService {
         ];
       }
     }
-    LogHelper.d('GERY GERY: sendTransaction Done wit if: ');
-
-    LogHelper.d('GERY GERY: sendTransaction Action: ' + actions.toString());
-
     final transaction = _buildTransaction(actions, accountName);
 
     final UserAuthData? userAuthData = await secureStorageService.getUserAuthData();
     LogHelper.d('GERY GERY: ${userAuthData?.eOSPrivateKey?.toString()}');
 
-    return EOSClient(baseUrl: 'http://eos.greymass.com', privateKeys: ['NIK ENTER YOUR KEY'], version: 'v1')
+    // ignore: prefer_interpolation_to_compose_strings
+    print('GERY GERY: sendTransaction : ' + transaction.toJson().toString());
+
+    // final dio.Response resp = await eosClient.pushTransaction(transaction);
+
+    return eosClient
         .pushTransaction(transaction)
-        .then((dynamic response) => _mapEosResponse(response, (dynamic map) {
-              return response['transaction_id'];
+        .then((dio.Response response) => _mapEosResponse(response, (dynamic map) {
+              return map['transaction_id'];
             }))
-        .catchError((error) => _mapEosError(error));
+        .catchError((error, s) => _mapEosError(error, s));
   }
 
-  FutureOr<Result<T>> _mapEosResponse<T>(dynamic response, Function modelMapper) {
-    print('mapEosResponse - transaction id: ${response['transaction_id']}');
-    if (response['transaction_id'] != null) {
-      print('Model Class: $modelMapper');
-      final map = Map<String, dynamic>.from(response);
+  FutureOr<Result<T>> _mapEosResponse<T>(dio.Response response, Function modelMapper) {
+    if (response.data['transaction_id'] != null) {
+      final map = Map<String, dynamic>.from(response.data);
       return ValueResult(modelMapper(map));
     } else {
-      print('ErrorResult: $response');
-      return ErrorResult(EosError(response['processed']['error_code']));
+      return ErrorResult(EosError(response.data['processed']['error_code']));
     }
   }
 
@@ -76,8 +73,11 @@ class EOSService {
     return transaction;
   }
 
-  ErrorResult _mapEosError(dynamic error) {
+  ErrorResult _mapEosError(dynamic error, StackTrace? s) {
     print('mapEosError: $error');
+    if (s != null) {
+      print('stack: $s');
+    }
     return ErrorResult(error);
   }
 }

--- a/lib/core/network/api/eos_service.dart
+++ b/lib/core/network/api/eos_service.dart
@@ -4,6 +4,8 @@ import 'package:async/async.dart';
 import 'package:dio/dio.dart' as dio;
 import 'package:hypha_wallet/core/crypto/eosdart/eosdart.dart';
 import 'package:hypha_wallet/core/crypto/seeds_esr/eos_transaction.dart';
+import 'package:hypha_wallet/core/local/models/user_auth_data.dart';
+import 'package:hypha_wallet/core/local/services/secure_storage_service.dart';
 import 'package:hypha_wallet/core/logging/log_helper.dart';
 
 String onboardingPrivateKey = '5JhM4vypLzLdDtHo67TR5RtmsYm2mr8F2ugqcrCzfrMPLvo8cQW';

--- a/lib/core/network/api/eos_service.dart
+++ b/lib/core/network/api/eos_service.dart
@@ -27,11 +27,8 @@ class EOSService {
   }) async {
     final actions = eosTransaction.actions.map((e) => e.toEosAction).toList();
 
-    LogHelper.d('GERY GERY: sendTransaction ' + actions.toString());
     for (final action in actions) {
-      LogHelper.d('GERY GERY: sendTransaction Action: ' + action.toString());
       if (action.authorization == null || action.authorization == []) {
-        LogHelper.d('GERY GERY: sendTransaction Inside check: ');
         action.authorization = [
           Authorization()
             ..actor = accountName
@@ -40,15 +37,7 @@ class EOSService {
       }
     }
     final transaction = _buildTransaction(actions, accountName);
-
     final UserAuthData? userAuthData = await secureStorageService.getUserAuthData();
-    LogHelper.d('GERY GERY: ${userAuthData?.eOSPrivateKey?.toString()}');
-
-    // ignore: prefer_interpolation_to_compose_strings
-    print('GERY GERY: sendTransaction : ' + transaction.toJson().toString());
-
-    // final dio.Response resp = await eosClient.pushTransaction(transaction);
-
     return eosClient
         .pushTransaction(transaction)
         .then((dio.Response response) => _mapEosResponse(response, (dynamic map) {

--- a/lib/core/network/api/eos_service.dart
+++ b/lib/core/network/api/eos_service.dart
@@ -17,6 +17,9 @@ class EOSService {
   EOSService(this.eosClient, this.secureStorageService);
 
   EOSClient _withPrivateKey(String privateKey) {
+    // This is weird - why not just create a new EOS client every time?
+    // This side-loads a global factory obkect and sets its keys, which sounds
+    // like a recipe for trouble. Nik.
     eosClient.privateKeys = [privateKey];
     return eosClient;
   }
@@ -38,7 +41,7 @@ class EOSService {
     }
     final transaction = _buildTransaction(actions, accountName);
     final UserAuthData? userAuthData = await secureStorageService.getUserAuthData();
-    return eosClient
+    return _withPrivateKey(userAuthData!.eOSPrivateKey.toString())
         .pushTransaction(transaction)
         .then((dio.Response response) => _mapEosResponse(response, (dynamic map) {
               return map['transaction_id'];


### PR DESCRIPTION
Took the important parts from my test PR

However, I would also recommend the following changes:

Don't use a global EOSClient object - there's no good reason for it, and modifying the global object as a side effect of making a transaction is not good.

Just create them as needed. 

2 - Let's have one EOSClient for read operations and one or more for sending transactions

The reason is that all the nodes have different features enabled and disabled, like v1, v2, history, and so on. 

The load balancer takes care of this, so we want to use the load balancer for all "read" calls

You reported that the load balancer node was too slow to execute our (very heavy) DAO calls, so for pushing transactions, let's assemble a list of beefy telos nodes, and use those. 
