### PR TITLE
Auth bug - Fixed. 

### DIFF
--- a/lib/ui/blocs/authentication/authentication_bloc.dart
+++ b/lib/ui/blocs/authentication/authentication_bloc.dart
@@ -30,6 +30,7 @@ class AuthenticationBloc extends Bloc<AuthenticationEvent, AuthenticationState> 
     on<_InitialAuthentication>(_initial);
     on<_AuthenticationStatusChanged>(_onAuthenticationStatusChanged);
     on<_AuthenticationLogoutRequested>(_onAuthenticationLogoutRequested);
+    on<_OnAuthenticatedDataChanged>(_onAuthenticatedDataChanged);
     _authenticationStatusSubscription = _authRepository.status.listen(
       (status) => add(AuthenticationEvent.authenticationStatusChanged(status)),
     );
@@ -98,5 +99,9 @@ class AuthenticationBloc extends Bloc<AuthenticationEvent, AuthenticationState> 
     Emitter<AuthenticationState> emit,
   ) async {
     await _authRepository.signOut();
+  }
+
+  FutureOr<void> _onAuthenticatedDataChanged(_OnAuthenticatedDataChanged event, Emitter<AuthenticationState> emit) {
+    emit(state.copyWith(userProfileData: event.data));
   }
 }


### PR DESCRIPTION
Unhandled Exception: Bad state: add(_$_OnAuthenticatedDataChanged) was called without a registered event handler.

^^ This is all you need to see where the issue is. This is again nothing to do with code generation, This can also happen when we create models without code generation.

What is wrong is that we call this event onUserProfileDataChanged but in the bloc we dont listen for this event

on<_OnAuthenticatedDataChanged>(_onAuthenticatedDataChanged); -> This line of code is missing.

This was an issue i added with the recent auth refactor.