### PR TITLE
Multiple Network Support

### DIFF
--- a/lib/core/crypto/dart_esr/src/encoding_options.dart
+++ b/lib/core/crypto/dart_esr/src/encoding_options.dart
@@ -7,19 +7,20 @@ import 'package:hypha_wallet/core/crypto/dart_esr/src/models/request_signature.d
 import 'package:hypha_wallet/core/crypto/dart_esr/zlib/archive.dart';
 import 'package:hypha_wallet/core/crypto/eosdart/eosdart.dart';
 
-SigningRequestEncodingOptions defaultSigningRequestEncodingOptions(
-        {String nodeUrl = 'https://eos.eosn.io', String nodeVersion = 'v1'}) =>
+SigningRequestEncodingOptions defaultSigningRequestEncodingOptions({String? nodeUrl, String nodeVersion = 'v1'}) =>
     SigningRequestEncodingOptions(
       textEncoder: DefaultTextEncoder(),
       textDecoder: DefaultTextDecoder(),
       zlib: DefaultZlibProvider(),
-      abiProvider: DefaultAbiProvider(
-        EOSClient(
-          baseUrl: nodeUrl,
-          privateKeys: [],
-          version: 'v1',
-        ),
-      ),
+      abiProvider: nodeUrl == null
+          ? null
+          : DefaultAbiProvider(
+              EOSClient(
+                baseUrl: nodeUrl,
+                privateKeys: [],
+                version: 'v1',
+              ),
+            ),
     );
 
 class DefaultZlibProvider implements ZlibProvider {

--- a/lib/core/crypto/dart_esr/src/signing_request_manager.dart
+++ b/lib/core/crypto/dart_esr/src/signing_request_manager.dart
@@ -1,10 +1,14 @@
 import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
+import 'package:get_it/get_it.dart';
 import 'package:hypha_wallet/core/crypto/dart_esr/dart_esr.dart';
 import 'package:hypha_wallet/core/crypto/dart_esr/src/models/request_signature.dart';
 import 'package:hypha_wallet/core/crypto/dart_esr/src/utils/base64u.dart';
 import 'package:hypha_wallet/core/crypto/eosdart/eosdart.dart' as eosDart;
+import 'package:hypha_wallet/core/crypto/eosdart/src/client.dart';
+import 'package:hypha_wallet/core/network/api/eos_service.dart';
+import 'package:hypha_wallet/core/network/api/remote_config_serivice.dart';
 
 class SigningRequestManager {
   static eosDart.Type? type(int version) => ESRConstants.signingRequestAbiType(version)['signing_request'];
@@ -38,9 +42,8 @@ class SigningRequestManager {
   /// Create a new signing request. */
   static Future<SigningRequestManager> create(
     SigningRequestCreateArguments args, {
-    SigningRequestEncodingOptions? options,
+    required SigningRequestEncodingOptions options,
   }) async {
-    options ??= defaultSigningRequestEncodingOptions();
     final TextEncoder? textEncoder = (options.textEncoder ?? DefaultTextEncoder) as TextEncoder?;
     final TextDecoder? textDecoder = (options.textDecoder ?? TextDecoder) as TextDecoder?;
 
@@ -126,7 +129,7 @@ class SigningRequestManager {
 
   /// Creates an identity request. */
   static Future<SigningRequestManager> identity(SigningRequestCreateIdentityArguments args,
-      {SigningRequestEncodingOptions? options}) async {
+      {required SigningRequestEncodingOptions options}) async {
     final permission = Authorization();
     permission.actor = args.account != null || args.account!.isEmpty ? args.account : ESRConstants.PlaceholderName;
     permission.permission =
@@ -212,8 +215,11 @@ class SigningRequestManager {
 
     final signingRequest = SigningRequest.fromBinary(type(version)!, buf);
 
-    print("signingRequest.chainId ${signingRequest.chainId}");
-    // TODO - select network here
+    // resolve network and abi provider -
+    final network = HyphaSigningRequestManager.resolveNetwork(signingRequest.chainId);
+    print("network: $network");
+    final eosClientForAbi = GetIt.I.get<EOSService>().getEosClientForNetwork(network);
+    final abiProvider = DefaultAbiProvider(eosClientForAbi);
 
     RequestSignature? signature;
     if (buf.haveReadData()) {
@@ -221,7 +227,7 @@ class SigningRequestManager {
     }
 
     return SigningRequestManager(version, signingRequest, textEncoder as TextEncoder?, textDecoder as TextDecoder?,
-        zlib: options.zlib, abiProvider: options.abiProvider, signature: signature);
+        zlib: options.zlib, abiProvider: abiProvider, signature: signature);
   }
 
   /// Sign the request, mutating.
@@ -769,7 +775,7 @@ class SigningRequestUtils {
   }
 
   /// Resolve a chain id to a chain name alias, returns UNKNOWN (0x00) if the chain id has no alias. */
-  ChainName idToName(String chainId) {
+  static ChainName idToName(String chainId) {
     chainId = chainId.toLowerCase();
     ESRConstants.ChainIdLookup.containsValue(chainId);
     return ESRConstants.ChainIdLookup.keys.firstWhere((key) => ESRConstants.ChainIdLookup[key] == chainId);
@@ -781,5 +787,43 @@ class SigningRequestUtils {
       return ESRConstants.ChainIdLookup[chainName];
     }
     return ESRConstants.ChainIdLookup[ChainName.RESERVED];
+  }
+}
+
+extension HyphaSigningRequestManager on SigningRequestManager {
+  /// Convert the ESR standard's "chain_id" to our Network
+  /// Both signify a unique identifier for a chain
+  /// But we support fewer chains than ESR does.
+  /// Networks maps to remote config which contains the server node URLs we need
+  /// to use in order to access supported chains.
+  /// Returns: Network
+  /// throws: unsupported network when the chainID can't be parsed.
+  ///
+  static Networks resolveNetwork(List<dynamic> chainId) {
+    if (chainId[0] == 'chain_alias') {
+      // chain_alias officially only supports EOS mainnet, and Telos mainnet, as 1, and 2.
+      if (chainId[1] == 1) {
+        return Networks.eos;
+      } else if (chainId[1] == 2) {
+        return Networks.telos;
+      } else {
+        throw 'unsupported network alias ${chainId[1]}';
+      }
+    } else if (chainId[0] == 'chain_id') {
+      final ChainName name = SigningRequestUtils.idToName(chainId[1]);
+      switch (name) {
+        case ChainName.EOS:
+          return Networks.eos;
+        case ChainName.EOS_JUNGLE4:
+          return Networks.eosTestnet;
+        case ChainName.TELOS:
+          return Networks.telos;
+        case ChainName.TELOS_TESTNET:
+          return Networks.telosTestnet;
+        default:
+          throw 'unsupported network ${name.name}';
+      }
+    }
+    return Networks.eos;
   }
 }

--- a/lib/core/crypto/dart_esr/src/utils/esr_constant.dart
+++ b/lib/core/crypto/dart_esr/src/utils/esr_constant.dart
@@ -7,7 +7,28 @@ import 'package:hypha_wallet/core/crypto/dart_esr/src/signing_request_abi.dart' 
 import 'package:hypha_wallet/core/crypto/dart_esr/src/signing_request_abi_v3.dart' as signing_request_v3_abis;
 import 'package:hypha_wallet/core/crypto/eosdart/eosdart.dart' as eosDart;
 
-enum ChainName { RESERVED, EOS, TELOS, EOS_JUNGLE2, KYLIN, WORBLI, BOS, MEETONE, INSIGHTS, BEOS, WAX, PROTON, FIO }
+/// Note: Only append at the end to this list since ESR is using the index of the chains as alias
+/// I don't think it's used much except for the first 2, EOS and TELOS, and in any case we don't
+/// currently support any of the other EOSIO networks anyway - we don't have the network endpoints etc.
+/// We only support EOS, TELOS, TELOS_TESTNET and EOS_JUNGLE4.
+///
+enum ChainName {
+  RESERVED,
+  EOS,
+  TELOS,
+  EOS_JUNGLE2,
+  KYLIN,
+  WORBLI,
+  BOS,
+  MEETONE,
+  INSIGHTS,
+  BEOS,
+  WAX,
+  PROTON,
+  FIO,
+  TELOS_TESTNET,
+  EOS_JUNGLE4,
+}
 
 class ESRConstants {
   static const int ProtocolVersion = 2;
@@ -50,5 +71,7 @@ class ESRConstants {
     ChainName.WAX: '1064487b3cd1a897ce03ae5b6a865651747e2e152090f99c1d19d44e01aea5a4',
     ChainName.PROTON: '384da888112027f0321850a169f737c33e53b388aad48b5adace4bab97f437e0',
     ChainName.FIO: '21dcae42c0182200e93f954a074011f9048a7624c6fe81d3c9541a614a88bd1c',
+    ChainName.TELOS_TESTNET: '1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f',
+    ChainName.EOS_JUNGLE4: '73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d',
   };
 }

--- a/lib/core/crypto/seeds_esr/eos_transaction.dart
+++ b/lib/core/crypto/seeds_esr/eos_transaction.dart
@@ -1,33 +1,36 @@
 import 'package:equatable/equatable.dart';
 import 'package:hypha_wallet/core/crypto/dart_esr/dart_esr.dart';
 import 'package:hypha_wallet/core/crypto/seeds_esr/eos_action.dart';
+import 'package:hypha_wallet/core/network/api/remote_config_serivice.dart';
 
 class EOSTransaction extends Equatable {
+  final Networks network;
   final List<EOSAction> actions;
   bool get isValid => actions.isNotEmpty;
 
   bool get isTransfer => actions.length == 1 && actions.first.name == 'transfer';
 
-  const EOSTransaction(this.actions);
+  const EOSTransaction(this.actions, this.network);
 
   @override
   List<Object?> get props => [actions];
 
-  factory EOSTransaction.fromESRActionsList(List<ESRAction> esrActions) {
+  factory EOSTransaction.fromESRActionsList(List<ESRAction> esrActions, Networks network) {
     final List<EOSAction> eosActions =
         esrActions.map((e) => EOSAction.fromESRAction(e)).where((item) => item.isValid).toList();
-    return EOSTransaction(eosActions);
+    return EOSTransaction(eosActions, network);
   }
 
   factory EOSTransaction.fromAction({
     required String account,
     required String actionName,
     required Map<String, dynamic> data,
+    required Networks network,
   }) =>
       EOSTransaction([
         EOSAction()
           ..account = account
           ..name = actionName
           ..data = data
-      ]);
+      ], network);
 }

--- a/lib/core/crypto/seeds_esr/seeds_esr.dart
+++ b/lib/core/crypto/seeds_esr/seeds_esr.dart
@@ -1,13 +1,8 @@
 import 'package:async/async.dart';
-import 'package:get_it/get_it.dart';
-import 'package:hypha_wallet/core/crypto/dart_esr/src/encoding_options.dart';
-import 'package:hypha_wallet/core/crypto/dart_esr/src/models/authorization.dart';
-import 'package:hypha_wallet/core/crypto/dart_esr/src/models/esr_action.dart';
-import 'package:hypha_wallet/core/crypto/dart_esr/src/signing_request_manager.dart';
+import 'package:hypha_wallet/core/crypto/dart_esr/dart_esr.dart';
 import 'package:hypha_wallet/core/crypto/seeds_esr/eos_transaction.dart';
 import 'package:hypha_wallet/core/crypto/seeds_esr/scan_qr_code_result_data.dart';
 import 'package:hypha_wallet/core/logging/log_helper.dart';
-import 'package:hypha_wallet/core/network/api/endpoints.dart';
 import 'package:hypha_wallet/core/network/api/remote_config_serivice.dart';
 // import 'package:hypha_wallet/core/crypto/eosdart/src/models/action.dart';
 
@@ -27,7 +22,14 @@ class SeedsESR {
   }
 
   Result<ScanQrCodeResultData> processResolvedRequest() {
-    final EOSTransaction eosTransaction = EOSTransaction.fromESRActionsList(actions);
+    Networks network;
+    try {
+      network = _resolveNetwork();
+    } catch (error) {
+      print('unable to resolve network: $error');
+      return ErrorResult(error);
+    }
+    final EOSTransaction eosTransaction = EOSTransaction.fromESRActionsList(actions, network);
     if (eosTransaction.isValid) {
       LogHelper.d('processResolvedRequest: Success QR');
       return ValueResult(ScanQrCodeResultData(transaction: eosTransaction, esr: this));
@@ -36,13 +38,17 @@ class SeedsESR {
       return ErrorResult('Unable to process this request');
     }
   }
+
+  /// Map ChainName or actual chain ID to our supported Network list
+  Networks _resolveNetwork() {
+    final List<dynamic> chainId = manager.signingRequest.chainId;
+    return HyphaSigningRequestManager.resolveNetwork(chainId);
+  }
 }
 
 extension TelosSigningManager on SigningRequestManager {
   static SigningRequestManager from(String? uri) {
-    return SigningRequestManager.from(uri,
-        options:
-            defaultSigningRequestEncodingOptions(nodeUrl: GetIt.I<RemoteConfigService>().pushTransactionNodeUrl()));
+    return SigningRequestManager.from(uri, options: defaultSigningRequestEncodingOptions());
   }
 
   Future<List<ESRAction>> fetchActions({String? account, String permission = 'active'}) async {

--- a/lib/core/network/api/eos_service.dart
+++ b/lib/core/network/api/eos_service.dart
@@ -14,9 +14,18 @@ class EOSService {
 
   EOSService(this.secureStorageService, this.remoteConfigService);
 
+  EOSClient getEosClientForNetwork(Networks network, {List<String> privateKeys = const []}) {
+    return EOSClient(
+      baseUrl: remoteConfigService.pushTransactionNodeUrl(network: network),
+      privateKeys: privateKeys,
+      version: 'v1',
+    );
+  }
+
   Future<Result<dynamic>> sendTransaction({
     required EOSTransaction eosTransaction,
     required String accountName,
+    required Networks network,
   }) async {
     final actions = eosTransaction.actions.map((e) => e.toEosAction).toList();
 
@@ -33,7 +42,7 @@ class EOSService {
     final UserAuthData? userAuthData = await secureStorageService.getUserAuthData();
 
     final eosClient = EOSClient(
-      baseUrl: remoteConfigService.pushTransactionNodeUrl(),
+      baseUrl: remoteConfigService.pushTransactionNodeUrl(network: network),
       privateKeys: [userAuthData!.eOSPrivateKey.toString()],
       version: 'v1',
     );

--- a/lib/core/network/api/remote_config_serivice.dart
+++ b/lib/core/network/api/remote_config_serivice.dart
@@ -32,8 +32,8 @@ class RemoteConfigService {
 
   // Node for push transactions - should be a fast server to prevent timeouts
   // network: default is Telos mainnet.
-  String pushTransactionNodeUrl({String? network}) {
-    final networkConfig = _getNetworkConfig(network: network);
+  String pushTransactionNodeUrl({required Networks network}) {
+    final networkConfig = _getNetworkConfig(network: network.name);
     final endpoint = networkConfig['fastEndpoint'];
     return endpoint;
   }

--- a/lib/ui/onboarding/import_account/usecases/find_account_use_case.dart
+++ b/lib/ui/onboarding/import_account/usecases/find_account_use_case.dart
@@ -14,9 +14,12 @@ class FindAccountsUseCase extends InputUseCase<Result<Iterable<UserProfileData>,
   FindAccountsUseCase(this._profileService, this.remoteConfigService);
 
   @override
-  Future<Result<Iterable<UserProfileData>, HyphaError>> run(String input) async {
+  Future<Result<Iterable<UserProfileData>, HyphaError>> run(String input, {Networks network = Networks.telos}) async {
+    /// TODO(n13)- change this to scan all known chains.
+    /// For this we need to find the correct PPP service for each chain, each chain uses a different PPP serivice
+    /// instance.
     final eosClient = EOSClient(
-      baseUrl: remoteConfigService.pushTransactionNodeUrl(),
+      baseUrl: remoteConfigService.pushTransactionNodeUrl(network: network),
       privateKeys: [],
       version: 'v1',
     );

--- a/lib/ui/sign_transaction/usecases/sign_transaction_use_case.dart
+++ b/lib/ui/sign_transaction/usecases/sign_transaction_use_case.dart
@@ -19,6 +19,7 @@ class SignTransactionUseCase extends InputUseCase<HResult.Result<String, HyphaEr
     final Result<dynamic> result = await eosService.sendTransaction(
       eosTransaction: input,
       accountName: userData?.accountName ?? '',
+      network: input.network,
     );
     if (result.isValue) {
       return HResult.Result.value(result.asValue!.value as String);


### PR DESCRIPTION
This is a major PR that adds support for other networks than Telos to our codebase. 

This is the first and most important aspect of it - all EOS Client access must specify the network it's running on. 

Providing Telos as a default is a way to not break existing code, but also temporary as eventually there won't be a default. 

Goal: Ability to parse any ESR code on any of our supported networks, and execute them, just as long as accounts and keys are present for that network. 

Other aspects of this:
- [Done] When providing an "abiProvider" we need to know the correct network. Abi provider accesses the provided node URL to download contract definitions (ABIs) and to resolve ESR encoded transactions. It's basically checking if the contract exists, if the action exists, and if the parameters exist / are correct. 
- [TBD] On import accounts, we need to scan all chains --> https://github.com/hypha-dao/hypha_wallet/issues/65
- [TBD] When we store accounts, we need to store the network with the account
- [TBD] Multi account support -> https://github.com/hypha-dao/hypha_wallet/issues/63
- [TBD] Other bits and pieces - maybe we will need a default network setting, but maybe we can get away without. It would be good if every UX in the wallet was aware of what network and what account it is referring to.
- --> https://github.com/hypha-dao/hypha_wallet/issues/66


Most of this can be post MVP. It's ok if we ship with Telos only, then add networks the next release. 

Also need to integrate PPP service for all these networks. Each chain gets their own PPP service.