### PR TITLE
Replace some text

### DIFF
--- a/lib/ui/sign_transaction/success/sign_transaction_success_page.dart
+++ b/lib/ui/sign_transaction/success/sign_transaction_success_page.dart
@@ -44,7 +44,7 @@ class SignTransactionSuccessPage extends StatelessWidget {
         ),
         children: <TextSpan>[
           TextSpan(
-            text: 'The transaction was successfully',
+            text: 'Transaction ',
             style: context.hyphaTextTheme.regular.copyWith(color: HyphaColors.primaryBlu),
           ),
           const TextSpan(text: ' '),
@@ -75,7 +75,7 @@ class SignTransactionSuccessPage extends StatelessWidget {
                 Image.asset('assets/images/thumb_up.png', width: 240, height: 240),
                 Padding(
                   padding: const EdgeInsets.only(left: 45, right: 45, top: 16),
-                  child: Text('Well Done!', textAlign: TextAlign.center, style: context.hyphaTextTheme.mediumTitles),
+                  child: Text('Success!', textAlign: TextAlign.center, style: context.hyphaTextTheme.mediumTitles),
                 ),
                 const SizedBox(height: 16),
                 Padding(padding: const EdgeInsets.only(left: 45, right: 45), child: successText),


### PR DESCRIPTION
Old text: 
Well Done!

The transaction was successfully approved.

New text: 

Success!

Transaction approved


Old text - well done - was weird because it implied the user was doing something - the app was doing something and is reporting back on success status. 

Also old text was longer while not actually adding any information that's not already on the green checkmark and our huge thumbs up ;) 