### PR TITLE
Fix expiration date parsing

### DIFF
--- a/lib/core/crypto/dart_esr/src/models/signing_request.dart
+++ b/lib/core/crypto/dart_esr/src/models/signing_request.dart
@@ -67,4 +67,23 @@ class SigningRequest {
     LogHelper.d('SigningRequest.fromBinary $deserializedData');
     return SigningRequest.fromJson(deserializedData);
   }
+
+  // return expiration for this signing request - can be null
+  DateTime? getExpiration() {
+    if (req.length > 1) {
+      final signRequestMap = req[1];
+      if (signRequestMap is Map) {
+        final expirationString = signRequestMap['expiration'];
+        if (expirationString != null) {
+          try {
+            final expirationDate = DateTime.parse(expirationString);
+            return expirationDate;
+          } catch (parseError) {
+            print('unable to parse date object: $expirationString');
+          }
+        }
+      }
+    }
+    return null;
+  }
 }

--- a/lib/ui/sign_transaction/interactor/data/transaction_action_data.dart
+++ b/lib/ui/sign_transaction/interactor/data/transaction_action_data.dart
@@ -14,10 +14,8 @@ class TransactionDetailsData {
   });
 
   factory TransactionDetailsData.fromQrCodeData(ScanQrCodeResultData data) {
-    final signRequestMap = data.esr.manager.signingRequest.req[1] as Map;
-    final expirationString = signRequestMap['expiration'];
     final expiration =
-        expirationString != null ? DateTime.parse(expirationString) : DateTime.now().add(const Duration(minutes: 3));
+        data.esr.manager.signingRequest.getExpiration() ?? DateTime.now().add(const Duration(minutes: 5));
 
     return TransactionDetailsData(
       signingTitle: 'From ${data.esr.actions.first.account}',


### PR DESCRIPTION
Bug: 

Some transactions fail on expiration date parsing

Fix: 
Better date parsing, moved date parsing into SigningRequest class because the code is esoteric. All has to do with the structure of a signing request. 

```
    final signRequestMap = data.esr.manager.signingRequest.req[1] as Map;
```

Would fail because sometimes that can be a List type object, causing a crash.

*** Steps to reproduce ***
In the DAO, redeem HUSD

*** Expected ***
It works

*** Actual ***
App crashes before showing the accept slider screen. 

*** Cause ***
Trying to cast List object to Map

