### PR TITLE
Bugfix/safe area sign flow

### DIFF
--- a/lib/ui/sign_transaction/components/sign_transaction_view.dart
+++ b/lib/ui/sign_transaction/components/sign_transaction_view.dart
@@ -15,53 +15,55 @@ class SignTransactionView extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<SignTransactionBloc, SignTransactionState>(
       builder: (context, state) {
-        return DecoratedBox(
-          decoration: BoxDecoration(
-            gradient: context.isDarkTheme ? HyphaColors.gradientBlack : HyphaColors.gradientWhite,
-            borderRadius: const BorderRadius.vertical(top: Radius.circular(30)),
-          ),
-          child: Column(
-            children: [
-              _Header('Signing request', state.transactionDetailsData.signingTitle),
-              Expanded(
-                child: SingleChildScrollView(
-                  child: Column(
-                    children: [
-                      const SizedBox(height: 8),
-                      ...state.transactionDetailsData.cards
-                          .map(
-                            (e) => Padding(
-                              padding: const EdgeInsets.all(22),
-                              child: HyphaTransactionActionCard(data: e),
-                            ),
-                          )
-                          .toList(),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 30),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Text(
-                              'This transaction expires in ',
-                              style: context.hyphaTextTheme.ralMediumSmallNote.copyWith(color: HyphaColors.midGrey),
-                            ),
-                            CountDownText(
-                              due: state.transactionDetailsData.expirationTime,
-                              finishedText: 'Expired',
-                              showLabel: true,
-                              longDateName: false,
-                              style: context.hyphaTextTheme.ralMediumSmallNote.copyWith(color: HyphaColors.midGrey),
-                            ),
-                          ],
-                        ),
-                      )
-                    ],
+        return SafeArea(
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: context.isDarkTheme ? HyphaColors.gradientBlack : HyphaColors.gradientWhite,
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(30)),
+            ),
+            child: Column(
+              children: [
+                _Header('Signing request', state.transactionDetailsData.signingTitle),
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: Column(
+                      children: [
+                        const SizedBox(height: 8),
+                        ...state.transactionDetailsData.cards
+                            .map(
+                              (e) => Padding(
+                                padding: const EdgeInsets.all(22),
+                                child: HyphaTransactionActionCard(data: e),
+                              ),
+                            )
+                            .toList(),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 30),
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Text(
+                                'This transaction expires in ',
+                                style: context.hyphaTextTheme.ralMediumSmallNote.copyWith(color: HyphaColors.midGrey),
+                              ),
+                              CountDownText(
+                                due: state.transactionDetailsData.expirationTime,
+                                finishedText: 'Expired',
+                                showLabel: true,
+                                longDateName: false,
+                                style: context.hyphaTextTheme.ralMediumSmallNote.copyWith(color: HyphaColors.midGrey),
+                              ),
+                            ],
+                          ),
+                        )
+                      ],
+                    ),
                   ),
                 ),
-              ),
-              const _Slider(),
-              const SizedBox(height: 8),
-            ],
+                const _Slider(),
+                const SizedBox(height: 8),
+              ],
+            ),
           ),
         );
       },
@@ -79,22 +81,20 @@ class _Slider extends StatelessWidget {
       child: Builder(
         builder: (context) {
           final GlobalKey<SlideActionState> _key = GlobalKey();
-          return SafeArea(
-            child: Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: SlideAction(
-                outerColor: context.isDarkTheme ? HyphaColors.lightBlack : HyphaColors.white,
-                key: _key,
-                onSubmit: () {
-                  context.read<SignTransactionBloc>().add(const SignTransactionEvent.onUserSlideCompleted());
-                },
-                onCancel: () {
-                  context.read<SignTransactionBloc>().add(const SignTransactionEvent.onUserSlideCanceled());
-                },
-                alignment: Alignment.center,
-                submittedIcon: const CircularProgressIndicator(),
-                child: Text('Slide to Sign', style: context.hyphaTextTheme.ralMediumSmallNote),
-              ),
+          return Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: SlideAction(
+              outerColor: context.isDarkTheme ? HyphaColors.lightBlack : HyphaColors.white,
+              key: _key,
+              onSubmit: () {
+                context.read<SignTransactionBloc>().add(const SignTransactionEvent.onUserSlideCompleted());
+              },
+              onCancel: () {
+                context.read<SignTransactionBloc>().add(const SignTransactionEvent.onUserSlideCanceled());
+              },
+              alignment: Alignment.center,
+              submittedIcon: const CircularProgressIndicator(),
+              child: Text('Slide to Sign', style: context.hyphaTextTheme.ralMediumSmallNote),
             ),
           );
         },

--- a/lib/ui/sign_transaction/components/sign_transaction_view.dart
+++ b/lib/ui/sign_transaction/components/sign_transaction_view.dart
@@ -79,20 +79,22 @@ class _Slider extends StatelessWidget {
       child: Builder(
         builder: (context) {
           final GlobalKey<SlideActionState> _key = GlobalKey();
-          return Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: SlideAction(
-              outerColor: context.isDarkTheme ? HyphaColors.lightBlack : HyphaColors.white,
-              key: _key,
-              onSubmit: () {
-                context.read<SignTransactionBloc>().add(const SignTransactionEvent.onUserSlideCompleted());
-              },
-              onCancel: () {
-                context.read<SignTransactionBloc>().add(const SignTransactionEvent.onUserSlideCanceled());
-              },
-              alignment: Alignment.center,
-              submittedIcon: const CircularProgressIndicator(),
-              child: Text('Slide to Sign', style: context.hyphaTextTheme.ralMediumSmallNote),
+          return SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: SlideAction(
+                outerColor: context.isDarkTheme ? HyphaColors.lightBlack : HyphaColors.white,
+                key: _key,
+                onSubmit: () {
+                  context.read<SignTransactionBloc>().add(const SignTransactionEvent.onUserSlideCompleted());
+                },
+                onCancel: () {
+                  context.read<SignTransactionBloc>().add(const SignTransactionEvent.onUserSlideCanceled());
+                },
+                alignment: Alignment.center,
+                submittedIcon: const CircularProgressIndicator(),
+                child: Text('Slide to Sign', style: context.hyphaTextTheme.ralMediumSmallNote),
+              ),
             ),
           );
         },

--- a/lib/ui/sign_transaction/components/sign_transaction_view.dart
+++ b/lib/ui/sign_transaction/components/sign_transaction_view.dart
@@ -75,7 +75,7 @@ class _Slider extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.all(8.0),
+      padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
       child: Builder(
         builder: (context) {
           final GlobalKey<SlideActionState> _key = GlobalKey();

--- a/lib/ui/sign_transaction/components/sign_transaction_view.dart
+++ b/lib/ui/sign_transaction/components/sign_transaction_view.dart
@@ -15,55 +15,53 @@ class SignTransactionView extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<SignTransactionBloc, SignTransactionState>(
       builder: (context, state) {
-        return SafeArea(
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              gradient: context.isDarkTheme ? HyphaColors.gradientBlack : HyphaColors.gradientWhite,
-              borderRadius: const BorderRadius.vertical(top: Radius.circular(30)),
-            ),
-            child: Column(
-              children: [
-                _Header('Signing request', state.transactionDetailsData.signingTitle),
-                Expanded(
-                  child: SingleChildScrollView(
-                    child: Column(
-                      children: [
-                        const SizedBox(height: 8),
-                        ...state.transactionDetailsData.cards
-                            .map(
-                              (e) => Padding(
-                                padding: const EdgeInsets.all(22),
-                                child: HyphaTransactionActionCard(data: e),
-                              ),
-                            )
-                            .toList(),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 30),
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Text(
-                                'This transaction expires in ',
-                                style: context.hyphaTextTheme.ralMediumSmallNote.copyWith(color: HyphaColors.midGrey),
-                              ),
-                              CountDownText(
-                                due: state.transactionDetailsData.expirationTime,
-                                finishedText: 'Expired',
-                                showLabel: true,
-                                longDateName: false,
-                                style: context.hyphaTextTheme.ralMediumSmallNote.copyWith(color: HyphaColors.midGrey),
-                              ),
-                            ],
-                          ),
-                        )
-                      ],
-                    ),
+        return DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: context.isDarkTheme ? HyphaColors.gradientBlack : HyphaColors.gradientWhite,
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(30)),
+          ),
+          child: Column(
+            children: [
+              _Header('Signing request', state.transactionDetailsData.signingTitle),
+              Expanded(
+                child: SingleChildScrollView(
+                  child: Column(
+                    children: [
+                      const SizedBox(height: 8),
+                      ...state.transactionDetailsData.cards
+                          .map(
+                            (e) => Padding(
+                              padding: const EdgeInsets.all(22),
+                              child: HyphaTransactionActionCard(data: e),
+                            ),
+                          )
+                          .toList(),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 30),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              'This transaction expires in ',
+                              style: context.hyphaTextTheme.ralMediumSmallNote.copyWith(color: HyphaColors.midGrey),
+                            ),
+                            CountDownText(
+                              due: state.transactionDetailsData.expirationTime,
+                              finishedText: 'Expired',
+                              showLabel: true,
+                              longDateName: false,
+                              style: context.hyphaTextTheme.ralMediumSmallNote.copyWith(color: HyphaColors.midGrey),
+                            ),
+                          ],
+                        ),
+                      )
+                    ],
                   ),
                 ),
-                const _Slider(),
-                const SizedBox(height: 8),
-              ],
-            ),
+              ),
+              const SafeArea(child: _Slider()),
+              const SizedBox(height: 8),
+            ],
           ),
         );
       },

--- a/lib/ui/sign_transaction/failed/sign_transaction_failed_page.dart
+++ b/lib/ui/sign_transaction/failed/sign_transaction_failed_page.dart
@@ -34,14 +34,16 @@ class SignTransactionFailedPage extends StatelessWidget {
       withGradient: true,
       child: Scaffold(
         backgroundColor: HyphaColors.transparent,
-        bottomNavigationBar: Padding(
-          padding: const EdgeInsets.only(left: 45, right: 45, bottom: 24),
-          child: HyphaAppButton(
-            buttonType: ButtonType.secondary,
-            onPressed: () {
-              Get.offAll(() => const HyphaBottomNavigation());
-            },
-            title: 'Close',
+        bottomNavigationBar: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.only(left: 45, right: 45, bottom: 16),
+            child: HyphaAppButton(
+              buttonType: ButtonType.secondary,
+              onPressed: () {
+                Get.offAll(() => const HyphaBottomNavigation());
+              },
+              title: 'Close',
+            ),
           ),
         ),
         body: Stack(

--- a/lib/ui/sign_transaction/success/sign_transaction_success_page.dart
+++ b/lib/ui/sign_transaction/success/sign_transaction_success_page.dart
@@ -57,13 +57,17 @@ class SignTransactionSuccessPage extends StatelessWidget {
       withGradient: true,
       child: Scaffold(
         backgroundColor: HyphaColors.transparent,
-        bottomNavigationBar: Padding(
-          padding: const EdgeInsets.only(left: 45, right: 45, bottom: 24),
-          child: HyphaAppButton(
-            onPressed: () {
-              Get.offAll(() => const HyphaBottomNavigation());
-            },
-            title: 'Close',
+        bottomNavigationBar: SafeArea(
+          child: Padding(
+            // TODO(gguji): We need a standard bottom offset for bottom UX elements - ideally HyphaBottomNavBar class takes a child element
+            // and does the right thing with safe area and offset.
+            padding: const EdgeInsets.only(left: 45, right: 45, bottom: 16),
+            child: HyphaAppButton(
+              onPressed: () {
+                Get.offAll(() => const HyphaBottomNavigation());
+              },
+              title: 'Close',
+            ),
           ),
         ),
         body: Stack(


### PR DESCRIPTION
## Bug
Several bottom elements were all cramped on the bottom of the screen on iPhone. It interferes with the phone's native "slide up" gesture on the bottom (the horizontal line), so needs to be moved up

## Fix
Safe area in sign transaction, and success and fail screen

Some of these are not the same height above the bottom - but that was the same before.

I tried to aim for "safe area + 16" for the distance from the bottom area. 

We could also make it safe area + 12 or +8. 

Once we decided we can make all bottom navigation bars uniform. 



## Before / After screenshots

Slide before
![IMG_5981](https://user-images.githubusercontent.com/65412/232358252-c1bc5c89-067d-40f3-b6af-3c4507f5c82b.PNG)

Slide after
![IMG_830CA8DEAF80-1](https://user-images.githubusercontent.com/65412/232358112-839313ae-994f-4ba2-b7f6-2e3494a640b0.jpeg)

Success before
![IMG_5983](https://user-images.githubusercontent.com/65412/232358511-351c03ec-a410-4413-b65c-e791bcc80a70.PNG)

Success after
![IMG_5985](https://user-images.githubusercontent.com/65412/232358531-0d137afd-f730-4ff0-bb18-34a5a5793444.PNG)


Fail before

![IMG_5987](https://user-images.githubusercontent.com/65412/232358192-832e14bb-a6f5-4bc1-8b37-f8ac469ffacd.PNG)

Fail after
![IMG_5988](https://user-images.githubusercontent.com/65412/232358199-fc29cede-2899-4856-8533-b9b2978b2b29.PNG)

