### PR TITLE
Feature/create profile when needed

### DIFF
--- a/lib/core/crypto/dart_esr/src/signing_request_manager.dart
+++ b/lib/core/crypto/dart_esr/src/signing_request_manager.dart
@@ -216,8 +216,6 @@ class SigningRequestManager {
 
     // resolve network and abi provider -
     final network = HyphaSigningRequestManager.resolveNetwork(signingRequest.chainId);
-    // TODO(NIK): Remove debug code
-    // print('network: $network');
     final eosClientForAbi = GetIt.I.get<EOSService>().getEosClientForNetwork(network);
     final abiProvider = DefaultAbiProvider(eosClientForAbi);
 
@@ -693,8 +691,7 @@ class ResolvedSigningRequest {
   }
 
   ResolvedCallback getCallback(List<String> signatures, {int? blockNum}) {
-    // TODO(n13): ResolvedSigningRequest getCallback 'not implemented yet'
-    throw 'not implemented yet';
+    throw 'not implemented.';
   }
 }
 

--- a/lib/core/di/bloc_module.dart
+++ b/lib/core/di/bloc_module.dart
@@ -25,6 +25,8 @@ void _registerBlocsModule() {
         _getIt<SetNameUseCase>(),
         _getIt<SetImageUseCase>(),
         _getIt<SetBioUseCase>(),
+        _getIt<ProfileLoginUseCase>(),
+        _getIt<InitializeProfileUseCase>(),
         _getIt<ErrorHandlerManager>(),
         _getIt<RemoveAvatarUseCase>(),
       ));

--- a/lib/core/di/usecases_module.dart
+++ b/lib/core/di/usecases_module.dart
@@ -22,9 +22,9 @@ void _registerUseCasesModule() {
     ),
   );
   _registerFactory(() => SetNameUseCase(_getIt<AmplifyService>()));
-  _registerFactory(() => SetImageUseCase(_getIt<AmplifyService>(), _getIt<ProfileLoginUseCase>()));
-  _registerFactory(() => SetBioUseCase(_getIt<AmplifyService>(), _getIt<ProfileLoginUseCase>()));
-  _registerFactory(() => RemoveAvatarUseCase(_getIt<AmplifyService>(), _getIt<ProfileLoginUseCase>()));
+  _registerFactory(() => SetImageUseCase(_getIt<AmplifyService>()));
+  _registerFactory(() => SetBioUseCase(_getIt<AmplifyService>()));
+  _registerFactory(() => RemoveAvatarUseCase(_getIt<AmplifyService>()));
   _registerFactory(() => DeleteAccountUseCase(_getIt<AmplifyService>(), _getIt<AuthRepository>()));
   _registerFactory(() => PPPSignUpUseCase(_getIt<AmplifyService>()));
   _registerFactory(() => ProfileLoginUseCase(_getIt<AmplifyService>()));

--- a/lib/core/error_handler/model/hypha_error.dart
+++ b/lib/core/error_handler/model/hypha_error.dart
@@ -8,6 +8,8 @@ class HyphaError {
   final String? actionText;
   final Function? action;
 
+  bool get isNotFoundError => type == HyphaErrorType.notFound;
+
   HyphaError({
     required this.message,
     required this.type,
@@ -21,6 +23,8 @@ class HyphaError {
   factory HyphaError.api(String message) => HyphaError(message: message, type: HyphaErrorType.api);
 
   factory HyphaError.generic(String message) => HyphaError(message: message, type: HyphaErrorType.generic);
+
+  factory HyphaError.notFound(String message) => HyphaError(message: message, type: HyphaErrorType.notFound);
 
   factory HyphaError.unknown(String? message) {
     return HyphaError(message: message ?? 'Unknown Error', type: HyphaErrorType.unknown);

--- a/lib/core/error_handler/model/hypha_error_type.dart
+++ b/lib/core/error_handler/model/hypha_error_type.dart
@@ -4,6 +4,7 @@ enum HyphaErrorType {
   tokenExpired,
   appVersionNotSupported,
   api,
+  notFound,
   custom,
   generic,
   unknown,

--- a/lib/core/network/api/aws_amplify/profile_upload_repository.dart
+++ b/lib/core/network/api/aws_amplify/profile_upload_repository.dart
@@ -121,7 +121,7 @@ class ProfileUploadRepository {
 
         case 3:
           if (data.fileName != null) {
-            final setImageResult = await _setImageUseCase.runFileName(data.fileName!, data.accountName);
+            final setImageResult = await _setImageUseCase.runFileName(data.fileName!);
             print('setImageResult: ${setImageResult.asValue?.value}');
             if (trueResult(setImageResult)) {
               data.step++;

--- a/lib/core/network/repository/profile_repository.dart
+++ b/lib/core/network/repository/profile_repository.dart
@@ -18,6 +18,8 @@ class ProfileService extends NetworkingManager {
       if (response.statusCode == 200) {
         final map = Map<String, dynamic>.from(response.data);
         return Result.value(ProfileData.fromJson(map));
+      } else if (response.statusCode == 404) {
+        return Result.error(HyphaError.notFound('No user account'));
       } else {
         print('get profile status error: ${response.statusCode} ${response.statusMessage}');
         return Result.error(HyphaError(type: HyphaErrorType.api, message: 'server error ${response.statusMessage}'));

--- a/lib/design/avatar_image/hypha_avatar_image.dart
+++ b/lib/design/avatar_image/hypha_avatar_image.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hypha_wallet/design/hypha_colors.dart';
@@ -69,7 +70,7 @@ class HyphaAvatarImage extends StatelessWidget {
         decoration: const BoxDecoration(gradient: HyphaColors.gradientBlu, shape: BoxShape.circle),
         child: Center(
           child: Text(
-            name!.characters.first.toUpperCase(),
+            name?.characters.firstOrNull?.toUpperCase() ?? '',
             style: context.hyphaTextTheme.regular.copyWith(
               color: HyphaColors.white,
               fontSize: imageRadius,

--- a/lib/ui/blocs/error_handler/error_handler_bloc.dart
+++ b/lib/ui/blocs/error_handler/error_handler_bloc.dart
@@ -51,6 +51,7 @@ class ErrorHandlerBloc extends Bloc<ErrorHandlerEvent, ErrorHandlerState> {
         }
         break;
       case HyphaErrorType.api:
+      case HyphaErrorType.notFound:
       case HyphaErrorType.unknown:
         emit(state.copyWith(pageCommand: PageCommand.showErrorMessage(hyphaError.message)));
         break;

--- a/lib/ui/profile/interactor/profile_bloc.dart
+++ b/lib/ui/profile/interactor/profile_bloc.dart
@@ -4,7 +4,6 @@ import 'package:bloc/bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:hypha_wallet/core/error_handler/error_handler_manager.dart';
 import 'package:hypha_wallet/core/error_handler/model/hypha_error.dart';
-import 'package:hypha_wallet/core/error_handler/model/hypha_error_type.dart';
 import 'package:hypha_wallet/core/network/models/user_profile_data.dart';
 import 'package:hypha_wallet/core/shared_preferences/hypha_shared_prefs.dart';
 import 'package:hypha_wallet/ui/architecture/interactor/page_states.dart';
@@ -66,7 +65,7 @@ class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
         final error = result.asError!.error;
         // if loading fails, show saved user data.
         final profileData = ProfileData(
-          name: userData.userName ?? '',
+          name: userData.userName,
           account: userData.accountName,
         );
         emit(state.copyWith(

--- a/lib/ui/profile/interactor/profile_bloc.freezed.dart
+++ b/lib/ui/profile/interactor/profile_bloc.freezed.dart
@@ -1386,6 +1386,7 @@ mixin _$ProfileState {
   PageState get pageState => throw _privateConstructorUsedError;
   PageCommand? get command => throw _privateConstructorUsedError;
   ProfileData? get profileData => throw _privateConstructorUsedError;
+  bool get doesNotHaveProfile => throw _privateConstructorUsedError;
   bool get showUpdateBioLoading => throw _privateConstructorUsedError;
   bool get showUpdateImageLoading => throw _privateConstructorUsedError;
   bool get showUpdateNameLoading => throw _privateConstructorUsedError;
@@ -1405,6 +1406,7 @@ abstract class $ProfileStateCopyWith<$Res> {
       {PageState pageState,
       PageCommand? command,
       ProfileData? profileData,
+      bool doesNotHaveProfile,
       bool showUpdateBioLoading,
       bool showUpdateImageLoading,
       bool showUpdateNameLoading});
@@ -1428,6 +1430,7 @@ class _$ProfileStateCopyWithImpl<$Res, $Val extends ProfileState>
     Object? pageState = null,
     Object? command = freezed,
     Object? profileData = freezed,
+    Object? doesNotHaveProfile = null,
     Object? showUpdateBioLoading = null,
     Object? showUpdateImageLoading = null,
     Object? showUpdateNameLoading = null,
@@ -1445,6 +1448,10 @@ class _$ProfileStateCopyWithImpl<$Res, $Val extends ProfileState>
           ? _value.profileData
           : profileData // ignore: cast_nullable_to_non_nullable
               as ProfileData?,
+      doesNotHaveProfile: null == doesNotHaveProfile
+          ? _value.doesNotHaveProfile
+          : doesNotHaveProfile // ignore: cast_nullable_to_non_nullable
+              as bool,
       showUpdateBioLoading: null == showUpdateBioLoading
           ? _value.showUpdateBioLoading
           : showUpdateBioLoading // ignore: cast_nullable_to_non_nullable
@@ -1485,6 +1492,7 @@ abstract class _$$_ProfileStateCopyWith<$Res>
       {PageState pageState,
       PageCommand? command,
       ProfileData? profileData,
+      bool doesNotHaveProfile,
       bool showUpdateBioLoading,
       bool showUpdateImageLoading,
       bool showUpdateNameLoading});
@@ -1507,6 +1515,7 @@ class __$$_ProfileStateCopyWithImpl<$Res>
     Object? pageState = null,
     Object? command = freezed,
     Object? profileData = freezed,
+    Object? doesNotHaveProfile = null,
     Object? showUpdateBioLoading = null,
     Object? showUpdateImageLoading = null,
     Object? showUpdateNameLoading = null,
@@ -1524,6 +1533,10 @@ class __$$_ProfileStateCopyWithImpl<$Res>
           ? _value.profileData
           : profileData // ignore: cast_nullable_to_non_nullable
               as ProfileData?,
+      doesNotHaveProfile: null == doesNotHaveProfile
+          ? _value.doesNotHaveProfile
+          : doesNotHaveProfile // ignore: cast_nullable_to_non_nullable
+              as bool,
       showUpdateBioLoading: null == showUpdateBioLoading
           ? _value.showUpdateBioLoading
           : showUpdateBioLoading // ignore: cast_nullable_to_non_nullable
@@ -1547,6 +1560,7 @@ class _$_ProfileState extends _ProfileState {
       {this.pageState = PageState.initial,
       this.command,
       this.profileData,
+      this.doesNotHaveProfile = false,
       this.showUpdateBioLoading = false,
       this.showUpdateImageLoading = false,
       this.showUpdateNameLoading = false})
@@ -1561,6 +1575,9 @@ class _$_ProfileState extends _ProfileState {
   final ProfileData? profileData;
   @override
   @JsonKey()
+  final bool doesNotHaveProfile;
+  @override
+  @JsonKey()
   final bool showUpdateBioLoading;
   @override
   @JsonKey()
@@ -1571,7 +1588,7 @@ class _$_ProfileState extends _ProfileState {
 
   @override
   String toString() {
-    return 'ProfileState(pageState: $pageState, command: $command, profileData: $profileData, showUpdateBioLoading: $showUpdateBioLoading, showUpdateImageLoading: $showUpdateImageLoading, showUpdateNameLoading: $showUpdateNameLoading)';
+    return 'ProfileState(pageState: $pageState, command: $command, profileData: $profileData, doesNotHaveProfile: $doesNotHaveProfile, showUpdateBioLoading: $showUpdateBioLoading, showUpdateImageLoading: $showUpdateImageLoading, showUpdateNameLoading: $showUpdateNameLoading)';
   }
 
   @override
@@ -1584,6 +1601,8 @@ class _$_ProfileState extends _ProfileState {
             (identical(other.command, command) || other.command == command) &&
             (identical(other.profileData, profileData) ||
                 other.profileData == profileData) &&
+            (identical(other.doesNotHaveProfile, doesNotHaveProfile) ||
+                other.doesNotHaveProfile == doesNotHaveProfile) &&
             (identical(other.showUpdateBioLoading, showUpdateBioLoading) ||
                 other.showUpdateBioLoading == showUpdateBioLoading) &&
             (identical(other.showUpdateImageLoading, showUpdateImageLoading) ||
@@ -1593,8 +1612,15 @@ class _$_ProfileState extends _ProfileState {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, pageState, command, profileData,
-      showUpdateBioLoading, showUpdateImageLoading, showUpdateNameLoading);
+  int get hashCode => Object.hash(
+      runtimeType,
+      pageState,
+      command,
+      profileData,
+      doesNotHaveProfile,
+      showUpdateBioLoading,
+      showUpdateImageLoading,
+      showUpdateNameLoading);
 
   @JsonKey(ignore: true)
   @override
@@ -1608,6 +1634,7 @@ abstract class _ProfileState extends ProfileState {
       {final PageState pageState,
       final PageCommand? command,
       final ProfileData? profileData,
+      final bool doesNotHaveProfile,
       final bool showUpdateBioLoading,
       final bool showUpdateImageLoading,
       final bool showUpdateNameLoading}) = _$_ProfileState;
@@ -1619,6 +1646,8 @@ abstract class _ProfileState extends ProfileState {
   PageCommand? get command;
   @override
   ProfileData? get profileData;
+  @override
+  bool get doesNotHaveProfile;
   @override
   bool get showUpdateBioLoading;
   @override

--- a/lib/ui/profile/interactor/profile_data.dart
+++ b/lib/ui/profile/interactor/profile_data.dart
@@ -10,7 +10,7 @@ class ProfileData {
   final bool? deleted;
 
   ProfileData({
-    required this.name,
+    this.name,
     required this.account,
     this.avatarUrl,
     this.bio,

--- a/lib/ui/profile/interactor/profile_state.dart
+++ b/lib/ui/profile/interactor/profile_state.dart
@@ -8,6 +8,7 @@ class ProfileState with _$ProfileState {
     @Default(PageState.initial) PageState pageState,
     PageCommand? command,
     ProfileData? profileData,
+    @Default(false) bool doesNotHaveProfile,
     @Default(false) bool showUpdateBioLoading,
     @Default(false) bool showUpdateImageLoading,
     @Default(false) bool showUpdateNameLoading,

--- a/lib/ui/profile/usecases/profile_login_use_case.dart
+++ b/lib/ui/profile/usecases/profile_login_use_case.dart
@@ -7,10 +7,10 @@ class ProfileLoginUseCase {
 
   ProfileLoginUseCase(this._amplifyService);
 
-  Future<Result<bool, HyphaError>> run(String accountName) async {
+  Future<Result<bool, HyphaError>> run(String accountName, {bool signUp = false}) async {
     try {
       // ignore: unused_local_variable
-      final res = await _amplifyService.loginUser(accountName);
+      final res = await _amplifyService.loginUser(accountName, isSignUp: signUp);
       return Result.value(true);
     } catch (error) {
       print('ProfileLoginUseCase error $error');

--- a/lib/ui/profile/usecases/remove_avatar_use_case.dart
+++ b/lib/ui/profile/usecases/remove_avatar_use_case.dart
@@ -1,27 +1,19 @@
 import 'package:hypha_wallet/core/error_handler/model/hypha_error.dart';
 import 'package:hypha_wallet/core/network/api/aws_amplify/amplify_service.dart';
 import 'package:hypha_wallet/ui/architecture/result/result.dart';
-import 'package:hypha_wallet/ui/profile/usecases/profile_login_use_case.dart';
 
 class RemoveAvatarUseCase {
   final AmplifyService _amplifyService;
-  final ProfileLoginUseCase _profileLoginUseCase;
 
-  RemoveAvatarUseCase(this._amplifyService, this._profileLoginUseCase);
+  RemoveAvatarUseCase(this._amplifyService);
 
-  Future<Result<bool, HyphaError>> run(String accountName) async {
+  Future<Result<bool, HyphaError>> run() async {
     try {
       print('remove avatar');
-      final Result<bool, HyphaError> loginResult = await _profileLoginUseCase.run(accountName);
 
-      if (loginResult.isValue) {
-        // ignore: unused_local_variable
-        final res = await _amplifyService.removeAvatar();
-        return Result.value(true);
-      } else {
-        print('Remove avatar error: login Failed ');
-        return Result.error(HyphaError.api('SetBioUseCase error: Login Failed'));
-      }
+      // ignore: unused_local_variable
+      final res = await _amplifyService.removeAvatar();
+      return Result.value(true);
     } catch (error) {
       print('RemoveAvatarUseCase error $error');
       print(error);

--- a/lib/ui/profile/usecases/set_bio_use_case.dart
+++ b/lib/ui/profile/usecases/set_bio_use_case.dart
@@ -1,27 +1,18 @@
 import 'package:hypha_wallet/core/error_handler/model/hypha_error.dart';
 import 'package:hypha_wallet/core/network/api/aws_amplify/amplify_service.dart';
 import 'package:hypha_wallet/ui/architecture/result/result.dart';
-import 'package:hypha_wallet/ui/profile/usecases/profile_login_use_case.dart';
 
 class SetBioUseCase {
   final AmplifyService _amplifyService;
-  final ProfileLoginUseCase _profileLoginUseCase;
 
-  SetBioUseCase(this._amplifyService, this._profileLoginUseCase);
+  SetBioUseCase(this._amplifyService);
 
   Future<Result<bool, HyphaError>> run(SetBioUseCaseInput input) async {
+    print('set bio to ${input.profileBio}');
     try {
-      print('set bio to ${input.profileBio}');
-      final Result<bool, HyphaError> loginResult = await _profileLoginUseCase.run(input.accountName);
-
-      if (loginResult.isValue) {
-        // ignore: unused_local_variable
-        final res = await _amplifyService.setBio(input.profileBio);
-        return Result.value(true);
-      } else {
-        print('SetBioUseCase error login Failed ');
-        return Result.error(HyphaError.api('SetBioUseCase error: Login Failed'));
-      }
+      // ignore: unused_local_variable
+      final res = await _amplifyService.setBio(input.profileBio);
+      return Result.value(true);
     } catch (error) {
       print('SetBioUseCase error $error');
       print(error);
@@ -31,8 +22,7 @@ class SetBioUseCase {
 }
 
 class SetBioUseCaseInput {
-  final String accountName;
   final String profileBio;
 
-  SetBioUseCaseInput({required this.accountName, required this.profileBio});
+  SetBioUseCaseInput({required this.profileBio});
 }

--- a/lib/ui/profile/usecases/set_image_use_case.dart
+++ b/lib/ui/profile/usecases/set_image_use_case.dart
@@ -5,43 +5,34 @@ import 'dart:io';
 import 'package:hypha_wallet/core/error_handler/model/hypha_error.dart';
 import 'package:hypha_wallet/core/network/api/aws_amplify/amplify_service.dart';
 import 'package:hypha_wallet/ui/architecture/result/result.dart';
-import 'package:hypha_wallet/ui/profile/usecases/profile_login_use_case.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:path/path.dart';
 
 class SetImageUseCase {
   final AmplifyService _amplifyService;
-  final ProfileLoginUseCase _profileLoginUseCase;
 
-  SetImageUseCase(this._amplifyService, this._profileLoginUseCase);
+  SetImageUseCase(this._amplifyService);
 
-  Future<Result<bool, HyphaError>> run(XFile image, String accountName) async {
+  Future<Result<bool, HyphaError>> run(XFile image) async {
     final File imageFile = File(image.path);
-    return runFile(imageFile, accountName);
+    return runFile(imageFile);
   }
 
-  Future<Result<bool, HyphaError>> runFileName(String filePath, String accountName) async {
+  Future<Result<bool, HyphaError>> runFileName(String filePath) async {
     final File imageFile = File(filePath);
-    return runFile(imageFile, accountName);
+    return runFile(imageFile);
   }
 
-  Future<Result<bool, HyphaError>> runFile(File image, String accountName) async {
+  Future<Result<bool, HyphaError>> runFile(File image) async {
     try {
-      final Result<bool, HyphaError> loginResult = await _profileLoginUseCase.run(accountName);
+      final File imageFile = File(image.path);
+      final fileExtension = extension(imageFile.path);
+      final filename = 'avatar-${DateTime.now().toIso8601String()}$fileExtension';
+      print('file size: ${imageFile.lengthSync()}');
+      print('file name: $filename');
 
-      if (loginResult.isValue) {
-        final File imageFile = File(image.path);
-        final fileExtension = extension(imageFile.path);
-        final filename = 'avatar-${DateTime.now().toIso8601String()}$fileExtension';
-        print('file size: ${imageFile.lengthSync()}');
-        print('file name: $filename');
-
-        final res = await _amplifyService.setPicture(imageFile, filename);
-        return Result.value(true);
-      } else {
-        print('SetImageUseCase error login Failed ');
-        return Result.error(HyphaError.api('SetImageUseCase error: Login Failed'));
-      }
+      final res = await _amplifyService.setPicture(imageFile, filename);
+      return Result.value(true);
     } catch (error) {
       print('SetImageUseCase error $error');
       print(error);

--- a/lib/ui/settings/interactor/settings_bloc.freezed.dart
+++ b/lib/ui/settings/interactor/settings_bloc.freezed.dart
@@ -1417,7 +1417,7 @@ class __$$_SettingsStateCopyWithImpl<$Res>
 
 class _$_SettingsState implements _SettingsState {
   const _$_SettingsState(
-      {this.pageState = PageState.initial,
+      {this.pageState = PageState.success,
       this.themeMode = ThemeMode.dark,
       this.showSecurityNotification = true,
       this.hasWords = false,

--- a/test/profile_upload_repository_test.dart
+++ b/test/profile_upload_repository_test.dart
@@ -58,7 +58,7 @@ class MockSignupUseCase extends PPPSignUpUseCase with MockUseCase {
 class MockProfileLoginUseCase extends ProfileLoginUseCase with MockUseCase {
   MockProfileLoginUseCase(super.amplifyService);
   @override
-  Future<Result<bool, HyphaError>> run(String accountName) async {
+  Future<Result<bool, HyphaError>> run(String accountName, {bool signUp = false}) async {
     return genericRun();
   }
 }
@@ -72,19 +72,19 @@ class MockInitializeProfileUseCase extends InitializeProfileUseCase with MockUse
 }
 
 class MockSetImageUseCase extends SetImageUseCase with MockUseCase {
-  MockSetImageUseCase(super.amplifyService, super._profileLoginUseCase);
+  MockSetImageUseCase(super.amplifyService);
   @override
-  Future<Result<bool, HyphaError>> runFileName(String filePath, String accountName) async {
+  Future<Result<bool, HyphaError>> runFileName(String filePath) async {
     return genericRun();
   }
 
   @override
-  Future<Result<bool, HyphaError>> run(XFile image, String accountName) async {
+  Future<Result<bool, HyphaError>> run(XFile image) async {
     return genericRun();
   }
 
   @override
-  Future<Result<bool, HyphaError>> runFile(File imageFile, String accountName) async {
+  Future<Result<bool, HyphaError>> runFile(File imageFile) async {
     return genericRun();
   }
 }
@@ -111,7 +111,7 @@ void main() {
     mockSignupUseCase = MockSignupUseCase(mockAmplifyService);
     mockProfileLoginUseCase = MockProfileLoginUseCase(mockAmplifyService);
     mockInitializeProfileUseCase = MockInitializeProfileUseCase(mockAmplifyService);
-    mockSetImageUseCase = MockSetImageUseCase(mockAmplifyService, mockProfileLoginUseCase);
+    mockSetImageUseCase = MockSetImageUseCase(mockAmplifyService);
     prefs = HyphaSharedPrefs(RxSharedPreferences(MockSharedPreferences()));
 
     service = ProfileUploadRepository(


### PR DESCRIPTION
**Reason for this PR**

Many cases users can log in but don't have a profile - for example Seeds users, or random Telos/EOS account holders. 

**Fix**

Detect when there is no profile, and run create profile and initialize profile in this case

**Reviewer Notes**
Moved check login code to Profile View bloc to remove duplicate code from use cases. 
When we detect that we need to sign up for profile service, we also need to "initialize" the profile - yet another quirk in the profile service, without this it doesn't work. 

Set name also checks for login / sign up / register correctly, so it can be implemented more easily. 

Arguably the check login/signup/init code could also live inside amplify service. 