### PR TITLE
add more correct 12 words key import, unit tests

### DIFF
--- a/lib/core/local/services/crypto_auth_service.dart
+++ b/lib/core/local/services/crypto_auth_service.dart
@@ -62,13 +62,32 @@ class CryptoAuthService {
     return childKey;
   }
 
-  // Create a private key from word seed as per Bip39 standard
-  // then create EOS key from seed
+  EOSPrivateKey createPrivateKeyFromWordsEOS(List<String> words) {
+    assert(words.length >= 12);
+    final mnemonic = words.join(' ');
+    // First, we create an ETH derived key for EOS
+    final ethKey = generateEthDerivedKeyEOS(mnemonic);
+    // Then we create an EOS key from the ETH derived key
+    final eosKey = EOSPrivateKey.fromBuffer(ethKey.privateKey);
+    return eosKey;
+  }
+
+  HDKey generateEthDerivedKeyEOS(String mnemonic) {
+    // Bip 44: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+    // Coin type for EOS 194: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+    // Reference: https://iancoleman.io/bip39/
+    final HDKey hdkey = HDKey.fromMnemonic(mnemonic);
+    const walletHdPath = "m/44'/194'/0'/0/0";
+    final HDKey childKey = hdkey.derive(walletHdPath);
+    return childKey;
+  }
+
+  // Create a private key from word seed as per Bip39
   // Minimum of 12 words must be provided.
   EOSPrivateKey createKeyBip39(List<String> words) {
     assert(words.length >= 12);
     final String mnemonic = words.join(' ');
-    final Uint8List seedBuffer = bip39.mnemonicToSeed(mnemonic);
-    return EOSPrivateKey.fromBuffer(seedBuffer);
+    final String seed = bip39.mnemonicToSeedHex(mnemonic);
+    return EOSPrivateKey.fromSeed(seed);
   }
 }

--- a/test/mnemonic_key_test.dart
+++ b/test/mnemonic_key_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hypha_wallet/core/local/services/crypto_auth_service.dart';
+
+void main() {
+  test('Import Seeds Light Wallet + Hypha Wallet key', () async {
+    final mnemonic = 'legal stereo tray wisdom erase abandon poverty journey pair drop fault master';
+    final expectedPrivateKey = '5KRLqbKNP5bE58TJHfic4a8jmr5ePKAdrK1nvEbNUQ8q1KR6E9s';
+    final expectedPublicKey = 'EOS5v2jhTXJMmhEbsH9LdiLj4y91F9cCEzwQ14HpSA5Azyxcwoqqf';
+
+    final authService = CryptoAuthService();
+
+    final authData = authService.createPrivateKeyFromWords(mnemonic.split(' '));
+
+    final eosKey = authData.eOSPrivateKey;
+
+    expect(eosKey.toString(), expectedPrivateKey);
+    expect(eosKey.toEOSPublicKey().toString(), expectedPublicKey);
+  });
+  test('Import Seeds Passport key', () async {
+    final mnemonic = 'upon what runway husband grief bomb evoke bicycle episode century crystal jazz';
+    final expectedPrivateKey = '5HpYGg6hfeD2a16PUoAf22AMzPFUuqDpBCMSbYGRmeDppJ8dyM9';
+    final expectedPublicKey = 'EOS5DmdNG4mv2tFrJY1yqctExqa34G2anXfaQ5sXeAwZTSnRFVH6Y';
+
+    final authService = CryptoAuthService();
+
+    final eosKey = authService.createPrivateKeyFrom12WordsSeedsGlobalPassport(mnemonic.split(' '));
+
+    expect(eosKey.toString(), expectedPrivateKey);
+    expect(eosKey.toEOSPublicKey().toString(), expectedPublicKey);
+  });
+  test('Import Bip39 + Bip44 EOS key', () async {
+    // test values from bip39 generator site: https://iancoleman.io/bip39/
+    final mnemonic =
+        'million false shift cheese fashion motion beyond increase animal horn chest course potato excuse advance';
+    final expectedPrivateKey = '5JJT5vekbbQMhkm7mJpvhe1KzFahDYwK5KLANJSdMTTZ6aBaTuX';
+    final expectedPublicKey = 'EOS59QJCQy2AW9tUZN6uRi3u6Ms1fKEaQtZhiGDUDsA8baZTbAtSw';
+
+    final authService = CryptoAuthService();
+    final eosKey = authService.createPrivateKeyFromWordsEOS(mnemonic.split(' '));
+
+    print('private: $eosKey');
+    print(' public: ${eosKey.toEOSPublicKey()}');
+
+    expect(eosKey.toString(), expectedPrivateKey);
+    expect(eosKey.toEOSPublicKey().toString(), expectedPublicKey);
+  });
+}


### PR DESCRIPTION
This PR adds method and links and unit test

Next PR will make change and also import all 3 possibilities. 

===============

So this was the best I could find how to generate a key from words for EOS

Set this website to "EOS" in the output
https://iancoleman.io/bip39/

I can also compare values there. 

We should use this going forward, then also import keys for all other methods.