### PR TITLE
ESR bugfix

### DIFF
--- a/lib/core/crypto/eosdart/src/numeric.dart
+++ b/lib/core/crypto/eosdart/src/numeric.dart
@@ -109,7 +109,7 @@ String binaryToDecimal(Uint8List bignum, {minDigits = 1}) {
 /// @param minDigits 0-pad result to this many digits
 String signedBinaryToDecimal(Uint8List bignum, {int minDigits = 1}) {
   if (isNegative(bignum)) {
-    var x = bignum.getRange(0, 0) as Uint8List;
+    var x = Uint8List.fromList(bignum.getRange(0, 0).toList());
     negate(x);
     return '-' + binaryToDecimal(x, minDigits: minDigits);
   }

--- a/lib/core/crypto/eosdart/src/serialize.dart
+++ b/lib/core/crypto/eosdart/src/serialize.dart
@@ -616,7 +616,9 @@ deserializeStruct(Type self, SerialBuffer buffer, {SerializerState? state, allow
       }
     }
     return result;
-  } catch (e) {
+  } catch (e, s) {
+    print('deserializeStruct error $e');
+    print('deserializeStruct error stack: $s');
     throw e;
   }
 }


### PR DESCRIPTION
Fix for QR code scan bug #150

We should probably scan this messy code for more errors like that...

**Analysis**

Was able to get the underlying error by adding some more printouts

```
#3      SigningRequestUtils.deserializeAction
signing_request_manager.dart:750
#4      SigningRequestManager.resolveActions.<anonymous closure>
signing_request_manager.dart:392
#5      MappedListIterable.elementAt (dart:_internal/iterable.dart:415:31)
#6      ListIterator.moveNext (dart:_internal/iterable.dart:344:26)
#7      new _GrowableList._ofEfficientLengthIterable (dart:core-patch/growable_array.dart:189:27)
#8      new _GrowableList.of (dart:core-patch/growable_array.dart:150:28)
#9      new List.of (dart:core-patch/array_patch.dart:52:28)
#10     L<…>
flutter: error: Error processing QR code [Error Type: HyphaErrorType.generic]
flutter: Error processing QR code [Error Type: HyphaErrorType.generic]

```