### PR TITLE
Handle esr and deep links

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,58 +1,711 @@
 PODS:
-  - Firebase/CoreOnly (10.3.0):
-    - FirebaseCore (= 10.3.0)
-  - Firebase/Crashlytics (10.3.0):
+  - abseil/algorithm (1.20211102.0):
+    - abseil/algorithm/algorithm (= 1.20211102.0)
+    - abseil/algorithm/container (= 1.20211102.0)
+  - abseil/algorithm/algorithm (1.20211102.0):
+    - abseil/base/config
+  - abseil/algorithm/container (1.20211102.0):
+    - abseil/algorithm/algorithm
+    - abseil/base/core_headers
+    - abseil/meta/type_traits
+  - abseil/base (1.20211102.0):
+    - abseil/base/atomic_hook (= 1.20211102.0)
+    - abseil/base/base (= 1.20211102.0)
+    - abseil/base/base_internal (= 1.20211102.0)
+    - abseil/base/config (= 1.20211102.0)
+    - abseil/base/core_headers (= 1.20211102.0)
+    - abseil/base/dynamic_annotations (= 1.20211102.0)
+    - abseil/base/endian (= 1.20211102.0)
+    - abseil/base/errno_saver (= 1.20211102.0)
+    - abseil/base/fast_type_id (= 1.20211102.0)
+    - abseil/base/log_severity (= 1.20211102.0)
+    - abseil/base/malloc_internal (= 1.20211102.0)
+    - abseil/base/pretty_function (= 1.20211102.0)
+    - abseil/base/raw_logging_internal (= 1.20211102.0)
+    - abseil/base/spinlock_wait (= 1.20211102.0)
+    - abseil/base/strerror (= 1.20211102.0)
+    - abseil/base/throw_delegate (= 1.20211102.0)
+  - abseil/base/atomic_hook (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+  - abseil/base/base (1.20211102.0):
+    - abseil/base/atomic_hook
+    - abseil/base/base_internal
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/dynamic_annotations
+    - abseil/base/log_severity
+    - abseil/base/raw_logging_internal
+    - abseil/base/spinlock_wait
+    - abseil/meta/type_traits
+  - abseil/base/base_internal (1.20211102.0):
+    - abseil/base/config
+    - abseil/meta/type_traits
+  - abseil/base/config (1.20211102.0)
+  - abseil/base/core_headers (1.20211102.0):
+    - abseil/base/config
+  - abseil/base/dynamic_annotations (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+  - abseil/base/endian (1.20211102.0):
+    - abseil/base/base
+    - abseil/base/config
+    - abseil/base/core_headers
+  - abseil/base/errno_saver (1.20211102.0):
+    - abseil/base/config
+  - abseil/base/fast_type_id (1.20211102.0):
+    - abseil/base/config
+  - abseil/base/log_severity (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+  - abseil/base/malloc_internal (1.20211102.0):
+    - abseil/base/base
+    - abseil/base/base_internal
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/dynamic_annotations
+    - abseil/base/raw_logging_internal
+  - abseil/base/pretty_function (1.20211102.0)
+  - abseil/base/raw_logging_internal (1.20211102.0):
+    - abseil/base/atomic_hook
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/log_severity
+  - abseil/base/spinlock_wait (1.20211102.0):
+    - abseil/base/base_internal
+    - abseil/base/core_headers
+    - abseil/base/errno_saver
+  - abseil/base/strerror (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/errno_saver
+  - abseil/base/throw_delegate (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/raw_logging_internal
+  - abseil/container/common (1.20211102.0):
+    - abseil/meta/type_traits
+    - abseil/types/optional
+  - abseil/container/compressed_tuple (1.20211102.0):
+    - abseil/utility/utility
+  - abseil/container/container_memory (1.20211102.0):
+    - abseil/base/config
+    - abseil/memory/memory
+    - abseil/meta/type_traits
+    - abseil/utility/utility
+  - abseil/container/fixed_array (1.20211102.0):
+    - abseil/algorithm/algorithm
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/dynamic_annotations
+    - abseil/base/throw_delegate
+    - abseil/container/compressed_tuple
+    - abseil/memory/memory
+  - abseil/container/flat_hash_map (1.20211102.0):
+    - abseil/algorithm/container
+    - abseil/container/container_memory
+    - abseil/container/hash_function_defaults
+    - abseil/container/raw_hash_map
+    - abseil/memory/memory
+  - abseil/container/hash_function_defaults (1.20211102.0):
+    - abseil/base/config
+    - abseil/hash/hash
+    - abseil/strings/cord
+    - abseil/strings/strings
+  - abseil/container/hash_policy_traits (1.20211102.0):
+    - abseil/meta/type_traits
+  - abseil/container/hashtable_debug_hooks (1.20211102.0):
+    - abseil/base/config
+  - abseil/container/hashtablez_sampler (1.20211102.0):
+    - abseil/base/base
+    - abseil/base/core_headers
+    - abseil/container/have_sse
+    - abseil/debugging/stacktrace
+    - abseil/memory/memory
+    - abseil/profiling/exponential_biased
+    - abseil/profiling/sample_recorder
+    - abseil/synchronization/synchronization
+    - abseil/utility/utility
+  - abseil/container/have_sse (1.20211102.0)
+  - abseil/container/inlined_vector (1.20211102.0):
+    - abseil/algorithm/algorithm
+    - abseil/base/core_headers
+    - abseil/base/throw_delegate
+    - abseil/container/inlined_vector_internal
+    - abseil/memory/memory
+  - abseil/container/inlined_vector_internal (1.20211102.0):
+    - abseil/base/core_headers
+    - abseil/container/compressed_tuple
+    - abseil/memory/memory
+    - abseil/meta/type_traits
+    - abseil/types/span
+  - abseil/container/layout (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/meta/type_traits
+    - abseil/strings/strings
+    - abseil/types/span
+    - abseil/utility/utility
+  - abseil/container/raw_hash_map (1.20211102.0):
+    - abseil/base/throw_delegate
+    - abseil/container/container_memory
+    - abseil/container/raw_hash_set
+  - abseil/container/raw_hash_set (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/endian
+    - abseil/container/common
+    - abseil/container/compressed_tuple
+    - abseil/container/container_memory
+    - abseil/container/hash_policy_traits
+    - abseil/container/hashtable_debug_hooks
+    - abseil/container/hashtablez_sampler
+    - abseil/container/have_sse
+    - abseil/memory/memory
+    - abseil/meta/type_traits
+    - abseil/numeric/bits
+    - abseil/utility/utility
+  - abseil/debugging/debugging_internal (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/dynamic_annotations
+    - abseil/base/errno_saver
+    - abseil/base/raw_logging_internal
+  - abseil/debugging/demangle_internal (1.20211102.0):
+    - abseil/base/base
+    - abseil/base/config
+    - abseil/base/core_headers
+  - abseil/debugging/stacktrace (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/debugging/debugging_internal
+  - abseil/debugging/symbolize (1.20211102.0):
+    - abseil/base/base
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/dynamic_annotations
+    - abseil/base/malloc_internal
+    - abseil/base/raw_logging_internal
+    - abseil/debugging/debugging_internal
+    - abseil/debugging/demangle_internal
+    - abseil/strings/strings
+  - abseil/functional/bind_front (1.20211102.0):
+    - abseil/base/base_internal
+    - abseil/container/compressed_tuple
+    - abseil/meta/type_traits
+    - abseil/utility/utility
+  - abseil/functional/function_ref (1.20211102.0):
+    - abseil/base/base_internal
+    - abseil/base/core_headers
+    - abseil/meta/type_traits
+  - abseil/hash/city (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/endian
+  - abseil/hash/hash (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/endian
+    - abseil/container/fixed_array
+    - abseil/hash/city
+    - abseil/hash/low_level_hash
+    - abseil/meta/type_traits
+    - abseil/numeric/int128
+    - abseil/strings/strings
+    - abseil/types/optional
+    - abseil/types/variant
+    - abseil/utility/utility
+  - abseil/hash/low_level_hash (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/endian
+    - abseil/numeric/bits
+    - abseil/numeric/int128
+  - abseil/memory (1.20211102.0):
+    - abseil/memory/memory (= 1.20211102.0)
+  - abseil/memory/memory (1.20211102.0):
+    - abseil/base/core_headers
+    - abseil/meta/type_traits
+  - abseil/meta (1.20211102.0):
+    - abseil/meta/type_traits (= 1.20211102.0)
+  - abseil/meta/type_traits (1.20211102.0):
+    - abseil/base/config
+  - abseil/numeric/bits (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+  - abseil/numeric/int128 (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/numeric/bits
+  - abseil/numeric/representation (1.20211102.0):
+    - abseil/base/config
+  - abseil/profiling/exponential_biased (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+  - abseil/profiling/sample_recorder (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/synchronization/synchronization
+    - abseil/time/time
+  - abseil/random/distributions (1.20211102.0):
+    - abseil/base/base_internal
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/meta/type_traits
+    - abseil/numeric/bits
+    - abseil/random/internal/distribution_caller
+    - abseil/random/internal/fast_uniform_bits
+    - abseil/random/internal/fastmath
+    - abseil/random/internal/generate_real
+    - abseil/random/internal/iostream_state_saver
+    - abseil/random/internal/traits
+    - abseil/random/internal/uniform_helper
+    - abseil/random/internal/wide_multiply
+    - abseil/strings/strings
+  - abseil/random/internal/distribution_caller (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/fast_type_id
+    - abseil/utility/utility
+  - abseil/random/internal/fast_uniform_bits (1.20211102.0):
+    - abseil/base/config
+    - abseil/meta/type_traits
+  - abseil/random/internal/fastmath (1.20211102.0):
+    - abseil/numeric/bits
+  - abseil/random/internal/generate_real (1.20211102.0):
+    - abseil/meta/type_traits
+    - abseil/numeric/bits
+    - abseil/random/internal/fastmath
+    - abseil/random/internal/traits
+  - abseil/random/internal/iostream_state_saver (1.20211102.0):
+    - abseil/meta/type_traits
+    - abseil/numeric/int128
+  - abseil/random/internal/nonsecure_base (1.20211102.0):
+    - abseil/base/core_headers
+    - abseil/meta/type_traits
+    - abseil/random/internal/pool_urbg
+    - abseil/random/internal/salted_seed_seq
+    - abseil/random/internal/seed_material
+    - abseil/types/optional
+    - abseil/types/span
+  - abseil/random/internal/pcg_engine (1.20211102.0):
+    - abseil/base/config
+    - abseil/meta/type_traits
+    - abseil/numeric/bits
+    - abseil/numeric/int128
+    - abseil/random/internal/fastmath
+    - abseil/random/internal/iostream_state_saver
+  - abseil/random/internal/platform (1.20211102.0):
+    - abseil/base/config
+  - abseil/random/internal/pool_urbg (1.20211102.0):
+    - abseil/base/base
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/endian
+    - abseil/base/raw_logging_internal
+    - abseil/random/internal/randen
+    - abseil/random/internal/seed_material
+    - abseil/random/internal/traits
+    - abseil/random/seed_gen_exception
+    - abseil/types/span
+  - abseil/random/internal/randen (1.20211102.0):
+    - abseil/base/raw_logging_internal
+    - abseil/random/internal/platform
+    - abseil/random/internal/randen_hwaes
+    - abseil/random/internal/randen_slow
+  - abseil/random/internal/randen_engine (1.20211102.0):
+    - abseil/base/endian
+    - abseil/meta/type_traits
+    - abseil/random/internal/iostream_state_saver
+    - abseil/random/internal/randen
+  - abseil/random/internal/randen_hwaes (1.20211102.0):
+    - abseil/base/config
+    - abseil/random/internal/platform
+    - abseil/random/internal/randen_hwaes_impl
+  - abseil/random/internal/randen_hwaes_impl (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/numeric/int128
+    - abseil/random/internal/platform
+  - abseil/random/internal/randen_slow (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/endian
+    - abseil/numeric/int128
+    - abseil/random/internal/platform
+  - abseil/random/internal/salted_seed_seq (1.20211102.0):
+    - abseil/container/inlined_vector
+    - abseil/meta/type_traits
+    - abseil/random/internal/seed_material
+    - abseil/types/optional
+    - abseil/types/span
+  - abseil/random/internal/seed_material (1.20211102.0):
+    - abseil/base/core_headers
+    - abseil/base/dynamic_annotations
+    - abseil/base/raw_logging_internal
+    - abseil/random/internal/fast_uniform_bits
+    - abseil/strings/strings
+    - abseil/types/optional
+    - abseil/types/span
+  - abseil/random/internal/traits (1.20211102.0):
+    - abseil/base/config
+  - abseil/random/internal/uniform_helper (1.20211102.0):
+    - abseil/base/config
+    - abseil/meta/type_traits
+    - abseil/random/internal/traits
+  - abseil/random/internal/wide_multiply (1.20211102.0):
+    - abseil/base/config
+    - abseil/numeric/bits
+    - abseil/numeric/int128
+    - abseil/random/internal/traits
+  - abseil/random/random (1.20211102.0):
+    - abseil/random/distributions
+    - abseil/random/internal/nonsecure_base
+    - abseil/random/internal/pcg_engine
+    - abseil/random/internal/pool_urbg
+    - abseil/random/internal/randen_engine
+    - abseil/random/seed_sequences
+  - abseil/random/seed_gen_exception (1.20211102.0):
+    - abseil/base/config
+  - abseil/random/seed_sequences (1.20211102.0):
+    - abseil/container/inlined_vector
+    - abseil/random/internal/nonsecure_base
+    - abseil/random/internal/pool_urbg
+    - abseil/random/internal/salted_seed_seq
+    - abseil/random/internal/seed_material
+    - abseil/random/seed_gen_exception
+    - abseil/types/span
+  - abseil/status/status (1.20211102.0):
+    - abseil/base/atomic_hook
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/raw_logging_internal
+    - abseil/container/inlined_vector
+    - abseil/debugging/stacktrace
+    - abseil/debugging/symbolize
+    - abseil/functional/function_ref
+    - abseil/strings/cord
+    - abseil/strings/str_format
+    - abseil/strings/strings
+    - abseil/types/optional
+  - abseil/status/statusor (1.20211102.0):
+    - abseil/base/base
+    - abseil/base/core_headers
+    - abseil/base/raw_logging_internal
+    - abseil/meta/type_traits
+    - abseil/status/status
+    - abseil/strings/strings
+    - abseil/types/variant
+    - abseil/utility/utility
+  - abseil/strings/cord (1.20211102.0):
+    - abseil/base/base
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/endian
+    - abseil/base/raw_logging_internal
+    - abseil/container/fixed_array
+    - abseil/container/inlined_vector
+    - abseil/functional/function_ref
+    - abseil/meta/type_traits
+    - abseil/strings/cord_internal
+    - abseil/strings/cordz_functions
+    - abseil/strings/cordz_info
+    - abseil/strings/cordz_statistics
+    - abseil/strings/cordz_update_scope
+    - abseil/strings/cordz_update_tracker
+    - abseil/strings/internal
+    - abseil/strings/str_format
+    - abseil/strings/strings
+    - abseil/types/optional
+  - abseil/strings/cord_internal (1.20211102.0):
+    - abseil/base/base_internal
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/endian
+    - abseil/base/raw_logging_internal
+    - abseil/base/throw_delegate
+    - abseil/container/compressed_tuple
+    - abseil/container/inlined_vector
+    - abseil/container/layout
+    - abseil/functional/function_ref
+    - abseil/meta/type_traits
+    - abseil/strings/strings
+    - abseil/types/span
+  - abseil/strings/cordz_functions (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/raw_logging_internal
+    - abseil/profiling/exponential_biased
+  - abseil/strings/cordz_handle (1.20211102.0):
+    - abseil/base/base
+    - abseil/base/config
+    - abseil/base/raw_logging_internal
+    - abseil/synchronization/synchronization
+  - abseil/strings/cordz_info (1.20211102.0):
+    - abseil/base/base
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/raw_logging_internal
+    - abseil/container/inlined_vector
+    - abseil/debugging/stacktrace
+    - abseil/strings/cord_internal
+    - abseil/strings/cordz_functions
+    - abseil/strings/cordz_handle
+    - abseil/strings/cordz_statistics
+    - abseil/strings/cordz_update_tracker
+    - abseil/synchronization/synchronization
+    - abseil/types/span
+  - abseil/strings/cordz_statistics (1.20211102.0):
+    - abseil/base/config
+    - abseil/strings/cordz_update_tracker
+  - abseil/strings/cordz_update_scope (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/strings/cord_internal
+    - abseil/strings/cordz_info
+    - abseil/strings/cordz_update_tracker
+  - abseil/strings/cordz_update_tracker (1.20211102.0):
+    - abseil/base/config
+  - abseil/strings/internal (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/endian
+    - abseil/base/raw_logging_internal
+    - abseil/meta/type_traits
+  - abseil/strings/str_format (1.20211102.0):
+    - abseil/strings/str_format_internal
+  - abseil/strings/str_format_internal (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/functional/function_ref
+    - abseil/meta/type_traits
+    - abseil/numeric/bits
+    - abseil/numeric/int128
+    - abseil/numeric/representation
+    - abseil/strings/strings
+    - abseil/types/optional
+    - abseil/types/span
+  - abseil/strings/strings (1.20211102.0):
+    - abseil/base/base
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/endian
+    - abseil/base/raw_logging_internal
+    - abseil/base/throw_delegate
+    - abseil/memory/memory
+    - abseil/meta/type_traits
+    - abseil/numeric/bits
+    - abseil/numeric/int128
+    - abseil/strings/internal
+  - abseil/synchronization/graphcycles_internal (1.20211102.0):
+    - abseil/base/base
+    - abseil/base/base_internal
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/malloc_internal
+    - abseil/base/raw_logging_internal
+  - abseil/synchronization/kernel_timeout_internal (1.20211102.0):
+    - abseil/base/core_headers
+    - abseil/base/raw_logging_internal
+    - abseil/time/time
+  - abseil/synchronization/synchronization (1.20211102.0):
+    - abseil/base/atomic_hook
+    - abseil/base/base
+    - abseil/base/base_internal
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/dynamic_annotations
+    - abseil/base/malloc_internal
+    - abseil/base/raw_logging_internal
+    - abseil/debugging/stacktrace
+    - abseil/debugging/symbolize
+    - abseil/synchronization/graphcycles_internal
+    - abseil/synchronization/kernel_timeout_internal
+    - abseil/time/time
+  - abseil/time (1.20211102.0):
+    - abseil/time/internal (= 1.20211102.0)
+    - abseil/time/time (= 1.20211102.0)
+  - abseil/time/internal (1.20211102.0):
+    - abseil/time/internal/cctz (= 1.20211102.0)
+  - abseil/time/internal/cctz (1.20211102.0):
+    - abseil/time/internal/cctz/civil_time (= 1.20211102.0)
+    - abseil/time/internal/cctz/time_zone (= 1.20211102.0)
+  - abseil/time/internal/cctz/civil_time (1.20211102.0):
+    - abseil/base/config
+  - abseil/time/internal/cctz/time_zone (1.20211102.0):
+    - abseil/base/config
+    - abseil/time/internal/cctz/civil_time
+  - abseil/time/time (1.20211102.0):
+    - abseil/base/base
+    - abseil/base/core_headers
+    - abseil/base/raw_logging_internal
+    - abseil/numeric/int128
+    - abseil/strings/strings
+    - abseil/time/internal/cctz/civil_time
+    - abseil/time/internal/cctz/time_zone
+  - abseil/types (1.20211102.0):
+    - abseil/types/any (= 1.20211102.0)
+    - abseil/types/bad_any_cast (= 1.20211102.0)
+    - abseil/types/bad_any_cast_impl (= 1.20211102.0)
+    - abseil/types/bad_optional_access (= 1.20211102.0)
+    - abseil/types/bad_variant_access (= 1.20211102.0)
+    - abseil/types/compare (= 1.20211102.0)
+    - abseil/types/optional (= 1.20211102.0)
+    - abseil/types/span (= 1.20211102.0)
+    - abseil/types/variant (= 1.20211102.0)
+  - abseil/types/any (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/fast_type_id
+    - abseil/meta/type_traits
+    - abseil/types/bad_any_cast
+    - abseil/utility/utility
+  - abseil/types/bad_any_cast (1.20211102.0):
+    - abseil/base/config
+    - abseil/types/bad_any_cast_impl
+  - abseil/types/bad_any_cast_impl (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/raw_logging_internal
+  - abseil/types/bad_optional_access (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/raw_logging_internal
+  - abseil/types/bad_variant_access (1.20211102.0):
+    - abseil/base/config
+    - abseil/base/raw_logging_internal
+  - abseil/types/compare (1.20211102.0):
+    - abseil/base/core_headers
+    - abseil/meta/type_traits
+  - abseil/types/optional (1.20211102.0):
+    - abseil/base/base_internal
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/memory/memory
+    - abseil/meta/type_traits
+    - abseil/types/bad_optional_access
+    - abseil/utility/utility
+  - abseil/types/span (1.20211102.0):
+    - abseil/algorithm/algorithm
+    - abseil/base/core_headers
+    - abseil/base/throw_delegate
+    - abseil/meta/type_traits
+  - abseil/types/variant (1.20211102.0):
+    - abseil/base/base_internal
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/meta/type_traits
+    - abseil/types/bad_variant_access
+    - abseil/utility/utility
+  - abseil/utility/utility (1.20211102.0):
+    - abseil/base/base_internal
+    - abseil/base/config
+    - abseil/meta/type_traits
+  - app_links (0.0.1):
+    - Flutter
+  - BoringSSL-GRPC (0.0.24):
+    - BoringSSL-GRPC/Implementation (= 0.0.24)
+    - BoringSSL-GRPC/Interface (= 0.0.24)
+  - BoringSSL-GRPC/Implementation (0.0.24):
+    - BoringSSL-GRPC/Interface (= 0.0.24)
+  - BoringSSL-GRPC/Interface (0.0.24)
+  - cloud_firestore (4.5.3):
+    - Firebase/Firestore (= 10.7.0)
+    - firebase_core
+    - Flutter
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+  - Firebase/CoreOnly (10.7.0):
+    - FirebaseCore (= 10.7.0)
+  - Firebase/Crashlytics (10.7.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 10.3.0)
-  - Firebase/DynamicLinks (10.3.0):
+    - FirebaseCrashlytics (~> 10.7.0)
+  - Firebase/DynamicLinks (10.7.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 10.3.0)
-  - Firebase/RemoteConfig (10.3.0):
+    - FirebaseDynamicLinks (~> 10.7.0)
+  - Firebase/Firestore (10.7.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 10.3.0)
-  - firebase_core (2.7.1):
-    - Firebase/CoreOnly (= 10.3.0)
+    - FirebaseFirestore (~> 10.7.0)
+  - Firebase/Messaging (10.7.0):
+    - Firebase/CoreOnly
+    - FirebaseMessaging (~> 10.7.0)
+  - Firebase/RemoteConfig (10.7.0):
+    - Firebase/CoreOnly
+    - FirebaseRemoteConfig (~> 10.7.0)
+  - firebase_core (2.10.0):
+    - Firebase/CoreOnly (= 10.7.0)
     - Flutter
   - firebase_crashlytics (3.0.16):
-    - Firebase/Crashlytics (= 10.3.0)
+    - Firebase/Crashlytics (= 10.7.0)
     - firebase_core
     - Flutter
   - firebase_dynamic_links (5.0.16):
-    - Firebase/DynamicLinks (= 10.3.0)
+    - Firebase/DynamicLinks (= 10.7.0)
+    - firebase_core
+    - Flutter
+  - firebase_messaging (14.4.1):
+    - Firebase/Messaging (= 10.7.0)
     - firebase_core
     - Flutter
   - firebase_remote_config (3.0.14):
-    - Firebase/RemoteConfig (= 10.3.0)
+    - Firebase/RemoteConfig (= 10.7.0)
     - firebase_core
     - Flutter
-  - FirebaseABTesting (10.3.0):
+  - FirebaseABTesting (10.9.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseCore (10.3.0):
+  - FirebaseCore (10.7.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreInternal (10.3.0):
-    - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseCrashlytics (10.3.0):
+  - FirebaseCoreExtension (10.9.0):
     - FirebaseCore (~> 10.0)
+  - FirebaseCoreInternal (10.9.0):
+    - "GoogleUtilities/NSData+zlib (~> 7.8)"
+  - FirebaseCrashlytics (10.7.0):
+    - FirebaseCore (~> 10.5)
     - FirebaseInstallations (~> 10.0)
+    - FirebaseSessions (~> 10.5)
     - GoogleDataTransport (~> 9.2)
     - GoogleUtilities/Environment (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (~> 2.1)
-  - FirebaseDynamicLinks (10.3.0):
+  - FirebaseDynamicLinks (10.7.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseInstallations (10.3.0):
+  - FirebaseFirestore (10.7.0):
+    - abseil/algorithm (~> 1.20211102.0)
+    - abseil/base (~> 1.20211102.0)
+    - abseil/container/flat_hash_map (~> 1.20211102.0)
+    - abseil/memory (~> 1.20211102.0)
+    - abseil/meta (~> 1.20211102.0)
+    - abseil/strings/strings (~> 1.20211102.0)
+    - abseil/time (~> 1.20211102.0)
+    - abseil/types (~> 1.20211102.0)
+    - FirebaseCore (~> 10.0)
+    - "gRPC-C++ (~> 1.44.0)"
+    - leveldb-library (~> 1.22)
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+  - FirebaseInstallations (10.9.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - FirebaseRemoteConfig (10.3.0):
+  - FirebaseMessaging (10.7.0):
+    - FirebaseCore (~> 10.0)
+    - FirebaseInstallations (~> 10.0)
+    - GoogleDataTransport (~> 9.2)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
+    - GoogleUtilities/Environment (~> 7.8)
+    - GoogleUtilities/Reachability (~> 7.8)
+    - GoogleUtilities/UserDefaults (~> 7.8)
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+  - FirebaseRemoteConfig (10.7.0):
     - FirebaseABTesting (~> 10.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
+  - FirebaseSessions (10.9.0):
+    - FirebaseCore (~> 10.5)
+    - FirebaseCoreExtension (~> 10.0)
+    - FirebaseInstallations (~> 10.0)
+    - GoogleDataTransport (~> 9.2)
+    - GoogleUtilities/Environment (~> 7.10)
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+    - PromisesSwift (~> 2.1)
   - Flutter (1.0.0)
   - flutter_secure_storage (6.0.0):
     - Flutter
@@ -77,21 +730,89 @@ PODS:
     - GoogleToolboxForMac/Defines (= 2.3.2)
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.3.2)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.3.2)"
+  - GoogleUtilities/AppDelegateSwizzler (7.10.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
   - GoogleUtilities/Environment (7.10.0):
     - PromisesObjC (< 3.0, >= 1.2)
   - GoogleUtilities/Logger (7.10.0):
     - GoogleUtilities/Environment
+  - GoogleUtilities/Network (7.10.0):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Reachability
   - "GoogleUtilities/NSData+zlib (7.10.0)"
+  - GoogleUtilities/Reachability (7.10.0):
+    - GoogleUtilities/Logger
   - GoogleUtilities/UserDefaults (7.10.0):
     - GoogleUtilities/Logger
   - GoogleUtilitiesComponents (1.1.0):
     - GoogleUtilities/Logger
+  - "gRPC-C++ (1.44.0)":
+    - "gRPC-C++/Implementation (= 1.44.0)"
+    - "gRPC-C++/Interface (= 1.44.0)"
+  - "gRPC-C++/Implementation (1.44.0)":
+    - abseil/base/base (= 1.20211102.0)
+    - abseil/base/core_headers (= 1.20211102.0)
+    - abseil/container/flat_hash_map (= 1.20211102.0)
+    - abseil/container/inlined_vector (= 1.20211102.0)
+    - abseil/functional/bind_front (= 1.20211102.0)
+    - abseil/hash/hash (= 1.20211102.0)
+    - abseil/memory/memory (= 1.20211102.0)
+    - abseil/random/random (= 1.20211102.0)
+    - abseil/status/status (= 1.20211102.0)
+    - abseil/status/statusor (= 1.20211102.0)
+    - abseil/strings/cord (= 1.20211102.0)
+    - abseil/strings/str_format (= 1.20211102.0)
+    - abseil/strings/strings (= 1.20211102.0)
+    - abseil/synchronization/synchronization (= 1.20211102.0)
+    - abseil/time/time (= 1.20211102.0)
+    - abseil/types/optional (= 1.20211102.0)
+    - abseil/types/variant (= 1.20211102.0)
+    - abseil/utility/utility (= 1.20211102.0)
+    - "gRPC-C++/Interface (= 1.44.0)"
+    - gRPC-Core (= 1.44.0)
+  - "gRPC-C++/Interface (1.44.0)"
+  - gRPC-Core (1.44.0):
+    - gRPC-Core/Implementation (= 1.44.0)
+    - gRPC-Core/Interface (= 1.44.0)
+  - gRPC-Core/Implementation (1.44.0):
+    - abseil/base/base (= 1.20211102.0)
+    - abseil/base/core_headers (= 1.20211102.0)
+    - abseil/container/flat_hash_map (= 1.20211102.0)
+    - abseil/container/inlined_vector (= 1.20211102.0)
+    - abseil/functional/bind_front (= 1.20211102.0)
+    - abseil/hash/hash (= 1.20211102.0)
+    - abseil/memory/memory (= 1.20211102.0)
+    - abseil/random/random (= 1.20211102.0)
+    - abseil/status/status (= 1.20211102.0)
+    - abseil/status/statusor (= 1.20211102.0)
+    - abseil/strings/cord (= 1.20211102.0)
+    - abseil/strings/str_format (= 1.20211102.0)
+    - abseil/strings/strings (= 1.20211102.0)
+    - abseil/synchronization/synchronization (= 1.20211102.0)
+    - abseil/time/time (= 1.20211102.0)
+    - abseil/types/optional (= 1.20211102.0)
+    - abseil/types/variant (= 1.20211102.0)
+    - abseil/utility/utility (= 1.20211102.0)
+    - BoringSSL-GRPC (= 0.0.24)
+    - gRPC-Core/Interface (= 1.44.0)
+    - Libuv-gRPC (= 0.0.10)
+  - gRPC-Core/Interface (1.44.0)
   - GTMSessionFetcher/Core (1.7.2)
   - image_cropper (0.0.4):
     - Flutter
     - TOCropViewController (~> 2.6.1)
   - image_picker_ios (0.0.1):
     - Flutter
+  - leveldb-library (1.22.2)
+  - Libuv-gRPC (0.0.10):
+    - Libuv-gRPC/Implementation (= 0.0.10)
+    - Libuv-gRPC/Interface (= 0.0.10)
+  - Libuv-gRPC/Implementation (0.0.10):
+    - Libuv-gRPC/Interface (= 0.0.10)
+  - Libuv-gRPC/Interface (0.0.10)
   - MLImage (1.0.0-beta3)
   - MLKitBarcodeScanning (2.2.0):
     - MLKitCommon (~> 8.0)
@@ -126,6 +847,8 @@ PODS:
   - permission_handler_apple (9.0.4):
     - Flutter
   - PromisesObjC (2.1.1)
+  - PromisesSwift (2.1.1):
+    - PromisesObjC (= 2.1.1)
   - Protobuf (3.21.12)
   - share_plus (0.0.1):
     - Flutter
@@ -137,9 +860,12 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
+  - app_links (from `.symlinks/plugins/app_links/ios`)
+  - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_crashlytics (from `.symlinks/plugins/firebase_crashlytics/ios`)
   - firebase_dynamic_links (from `.symlinks/plugins/firebase_dynamic_links/ios`)
+  - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
   - firebase_remote_config (from `.symlinks/plugins/firebase_remote_config/ios`)
   - Flutter (from `Flutter`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
@@ -154,36 +880,53 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
+    - abseil
+    - BoringSSL-GRPC
     - Firebase
     - FirebaseABTesting
     - FirebaseCore
+    - FirebaseCoreExtension
     - FirebaseCoreInternal
     - FirebaseCrashlytics
     - FirebaseDynamicLinks
+    - FirebaseFirestore
     - FirebaseInstallations
+    - FirebaseMessaging
     - FirebaseRemoteConfig
+    - FirebaseSessions
     - GoogleDataTransport
     - GoogleMLKit
     - GoogleToolboxForMac
     - GoogleUtilities
     - GoogleUtilitiesComponents
+    - "gRPC-C++"
+    - gRPC-Core
     - GTMSessionFetcher
+    - leveldb-library
+    - Libuv-gRPC
     - MLImage
     - MLKitBarcodeScanning
     - MLKitCommon
     - MLKitVision
     - nanopb
     - PromisesObjC
+    - PromisesSwift
     - Protobuf
     - TOCropViewController
 
 EXTERNAL SOURCES:
+  app_links:
+    :path: ".symlinks/plugins/app_links/ios"
+  cloud_firestore:
+    :path: ".symlinks/plugins/cloud_firestore/ios"
   firebase_core:
     :path: ".symlinks/plugins/firebase_core/ios"
   firebase_crashlytics:
     :path: ".symlinks/plugins/firebase_crashlytics/ios"
   firebase_dynamic_links:
     :path: ".symlinks/plugins/firebase_dynamic_links/ios"
+  firebase_messaging:
+    :path: ".symlinks/plugins/firebase_messaging/ios"
   firebase_remote_config:
     :path: ".symlinks/plugins/firebase_remote_config/ios"
   Flutter:
@@ -208,18 +951,27 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  Firebase: f92fc551ead69c94168d36c2b26188263860acd9
-  firebase_core: 1ae9f9aa76e6e1edc14fb181637ad466fd6c6fa4
-  firebase_crashlytics: 7fa4fcb9ebd555ac0546fd4ac9f16b4bea5c5218
-  firebase_dynamic_links: 42ab4dd387b07d5c7af2e9aa63a7b5fa3518dd8b
-  firebase_remote_config: 4788db7504c356174cbd09ffa3de344f928a8100
-  FirebaseABTesting: e6660693429b4663573c82f8d2f1041deff1753a
-  FirebaseCore: 988754646ab3bd4bdcb740f1bfe26b9f6c0d5f2a
-  FirebaseCoreInternal: 29b76f784d607df8b2a1259d73c3f04f1210137b
-  FirebaseCrashlytics: f20d956f8229010b645e534693c39e0b7843c268
-  FirebaseDynamicLinks: 51c81d07bd63155bb56d76b0abdda79c8a3d8d02
-  FirebaseInstallations: e2f26126089dcf41e215f7b8925af8d953c7d602
-  FirebaseRemoteConfig: c24f767c17b0440ee63c7e93380d599173556113
+  abseil: ebe5b5529fb05d93a8bdb7951607be08b7fa71bc
+  app_links: ab4ba54d10a13d45825336bc9707b5eadee81191
+  BoringSSL-GRPC: 3175b25143e648463a56daeaaa499c6cb86dad33
+  cloud_firestore: 13b9ec4f7e44d1ccd361a18f4275ed6d26d03ef2
+  Firebase: 0219acf760880eeec8ce479895bd7767466d9f81
+  firebase_core: 18d44f087248303a4a8f05d0099a000c46e3c77a
+  firebase_crashlytics: 79356a807c7ca35ee82370e88a2f23e45fd12275
+  firebase_dynamic_links: c570014c1eb817b66ee3401f52175825a817d18f
+  firebase_messaging: 90b11d16c537444a39e50b818ebe1a51ec0e38c2
+  firebase_remote_config: e5f1ed5b29191424280b7b249228f0ed64bc90ee
+  FirebaseABTesting: 005b70969e2817e2a1e631e8dba29134a04c0622
+  FirebaseCore: e317665b9d744727a97e623edbbed009320afdd7
+  FirebaseCoreExtension: d3e9bba2930a8033042112397cd9f006a1bb203d
+  FirebaseCoreInternal: d2b4acb827908e72eca47a9fd896767c3053921e
+  FirebaseCrashlytics: 35fdd1a433b31e28adcf5c8933f4c526691a1e0b
+  FirebaseDynamicLinks: 16a8fae3697fba66fed7a1d646fe59f30d42aa31
+  FirebaseFirestore: 3963a6edd1c84b4748dab3e2c62624a29d03eca1
+  FirebaseInstallations: c58489c9caacdbf27d1da60891a87318e20218e0
+  FirebaseMessaging: ac9062bcc35ed56e15a0241d8fd317022499baf8
+  FirebaseRemoteConfig: d5de62211e2eaa2152d8ee85a23c301b70887a74
+  FirebaseSessions: 44a6782502eb279a214d4adca20891353278760c
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
   GoogleDataTransport: 1c8145da7117bd68bbbed00cf304edb6a24de00f
@@ -227,9 +979,13 @@ SPEC CHECKSUMS:
   GoogleToolboxForMac: 8bef7c7c5cf7291c687cf5354f39f9db6399ad34
   GoogleUtilities: bad72cb363809015b1f7f19beb1f1cd23c589f95
   GoogleUtilitiesComponents: 679b2c881db3b615a2777504623df6122dd20afe
+  "gRPC-C++": 9675f953ace2b3de7c506039d77be1f2e77a8db2
+  gRPC-Core: 943e491cb0d45598b0b0eb9e910c88080369290b
   GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
   image_cropper: a3291c624a953049bc6a02e1f8c8ceb162a24b25
   image_picker_ios: 4a8aadfbb6dc30ad5141a2ce3832af9214a705b5
+  leveldb-library: f03246171cce0484482ec291f88b6d563699ee06
+  Libuv-gRPC: 55e51798e14ef436ad9bc45d12d43b77b49df378
   MLImage: 489dfec109f21da8621b28d476401aaf7a0d4ff4
   MLKitBarcodeScanning: d92fe1911001ec36870162c5a0eb206f612b7169
   MLKitCommon: f6da6c5659618c070b50a80db01248ebe2964175
@@ -239,12 +995,13 @@ SPEC CHECKSUMS:
   path_provider_foundation: c68054786f1b4f3343858c1e1d0caaded73f0be9
   permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
   PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
+  PromisesSwift: 99fddfe4a0ec88a56486644c0da106694c92a604
   Protobuf: 120350fc38646e2dedc26f49ecba778184ea1de2
   share_plus: 056a1e8ac890df3e33cb503afffaf1e9b4fbae68
   shared_preferences_foundation: 986fc17f3d3251412d18b0265f9c64113a8c2472
   TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863
   url_launcher_ios: 08a3dfac5fb39e8759aeb0abbd5d9480f30fc8b4
 
-PODFILE CHECKSUM: 3dc4c48e6e88a83e8aeecb7161097257983af1a0
+PODFILE CHECKSUM: e682fb28170dce53624b98ae862f558628b5b383
 
 COCOAPODS: 1.11.3

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -78,11 +78,12 @@ class HyphaAppView extends StatelessWidget {
           listenWhen: (previous, current) => previous.command != current.command,
           listener: (context, state) {
             state.command?.when(
-              navigateToCreateAccount: () => Get.offAll(
-                () => const OnboardingPageWithLink(),
-              ),
-            );
-
+                navigateToCreateAccount: () => Get.offAll(
+                      () => const OnboardingPageWithLink(),
+                    ),
+                navigateToSignTransaction: (ScanQrCodeResultData data) {
+                  _showSignTransactionBottomSheet(data);
+                });
             context.read<DeeplinkBloc>().add(const DeeplinkEvent.clearPageCommand());
           },
         ),
@@ -91,16 +92,7 @@ class HyphaAppView extends StatelessWidget {
           listenWhen: (previous, current) => previous.command != current.command,
           listener: (_, state) {
             state.command?.when(navigateToSignTransaction: (ScanQrCodeResultData data) {
-              Get.bottomSheet(
-                FractionallySizedBox(
-                  heightFactor: UIConstants.bottomSheetHeightFraction,
-                  child: SignTransactionPage(qrCodeData: data),
-                ),
-                isScrollControlled: true,
-                shape: const RoundedRectangleBorder(
-                  borderRadius: BorderRadius.vertical(top: Radius.circular(30)),
-                ),
-              );
+              _showSignTransactionBottomSheet(data);
             });
 
             context.read<PushNotificationsBloc>().add(const PushNotificationsEvent.clearPageCommand());
@@ -200,6 +192,19 @@ class HyphaAppView extends StatelessWidget {
             home: const SizedBox.shrink(),
           );
         },
+      ),
+    );
+  }
+
+  void _showSignTransactionBottomSheet(ScanQrCodeResultData data) {
+    Get.bottomSheet(
+      FractionallySizedBox(
+        heightFactor: UIConstants.bottomSheetHeightFraction,
+        child: SignTransactionPage(qrCodeData: data),
+      ),
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(30)),
       ),
     );
   }

--- a/lib/core/crypto/dart_esr/src/signing_request_manager.dart
+++ b/lib/core/crypto/dart_esr/src/signing_request_manager.dart
@@ -178,6 +178,12 @@ class SigningRequestManager {
     return SigningRequestManager.fromData(buf.asUint8List(), options: options);
   }
 
+  static bool isValidESRScheme(String uri) {
+    final splitUri = uri.split(':');
+    final scheme = splitUri[0];
+    return scheme == 'esr' || scheme == 'web+esr';
+  }
+
   /// Creates a signing request from encoded `esr:` uri string. */
   factory SigningRequestManager.from(String? uri, {required SigningRequestEncodingOptions options}) {
     if (uri is! String) {

--- a/lib/core/di/bloc_module.dart
+++ b/lib/core/di/bloc_module.dart
@@ -9,7 +9,7 @@ void _registerBlocsModule() {
         _getIt<FirebasePushNotificationsService>(),
         _getIt<FirebaseDatabaseService>(),
       ));
-  _registerFactory(() => DeeplinkBloc());
+  _registerFactory(() => DeeplinkBloc(_getIt<ParseQRCodeUseCase>()));
   _registerFactory(() => ErrorHandlerBloc(_getIt<ErrorHandlerManager>()));
   _registerFactory(
       () => SettingsBloc(_getIt<HyphaSharedPrefs>(), _getIt<SecureStorageService>(), _getIt<DeleteAccountUseCase>()));

--- a/lib/core/local/services/crypto_auth_service.dart
+++ b/lib/core/local/services/crypto_auth_service.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:bip39/bip39.dart' as bip39;
 import 'package:hdkey/hdkey.dart';
 import 'package:hypha_wallet/core/crypto/eosdart_ecc/src/key.dart';

--- a/lib/ui/blocs/deeplink/deeplink_bloc.dart
+++ b/lib/ui/blocs/deeplink/deeplink_bloc.dart
@@ -1,8 +1,11 @@
 import 'dart:async';
 
+import 'package:app_links/app_links.dart';
 import 'package:bloc/bloc.dart';
 import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:get/get.dart';
+import 'package:hypha_wallet/core/crypto/dart_esr/dart_esr.dart';
 import 'package:hypha_wallet/core/crypto/seeds_esr/scan_qr_code_result_data.dart';
 import 'package:hypha_wallet/core/logging/log_helper.dart';
 import 'package:hypha_wallet/ui/home_page/usecases/parse_qr_code_use_case.dart';
@@ -14,6 +17,10 @@ part 'page_command.dart';
 
 class DeeplinkBloc extends Bloc<DeeplinkEvent, DeeplinkState> {
   final ParseQRCodeUseCase _parseQRCodeUseCase;
+  final _appLinks = AppLinks();
+
+  StreamSubscription<String>? _linkSubscription;
+
   DeeplinkBloc(this._parseQRCodeUseCase) : super(const DeeplinkState()) {
     initDynamicLinks();
 
@@ -22,17 +29,58 @@ class DeeplinkBloc extends Bloc<DeeplinkEvent, DeeplinkState> {
     on<_ClearPageCommand>((_, emit) => emit(state.copyWith(command: null)));
   }
 
-  Future<void> initDynamicLinks() async {
-    final PendingDynamicLinkData? initialLink = await FirebaseDynamicLinks.instance.getInitialLink();
+  void _debugShowMessage(String message) {
+    Get.showSnackbar(GetSnackBar(message: message, duration: const Duration(seconds: 5)));
+  }
 
-    if (initialLink != null) {
-      LogHelper.d('initial link: ${initialLink.link}');
-      add(DeeplinkEvent.incomingFirebaseDeepLink(initialLink.link));
+  Future<void> initDynamicLinks() async {
+    /// Handle Firebase links - these don't react to ESR links but we check just in case
+    // final PendingDynamicLinkData? initialDeepLink = await FirebaseDynamicLinks.instance.getInitialLink();
+
+    // if (initialDeepLink != null) {
+    //   LogHelper.d('initial link: ${initialDeepLink.link}');
+    //   if (!initialDeepLink.link.isEsr()) {
+    //     _debugShowMessage('initial firebase link: ${initialDeepLink.link}');
+    //     add(DeeplinkEvent.incomingFirebaseDeepLink(initialDeepLink.link));
+    //   } else {
+    //     _debugShowMessage('initial esr link: ${initialDeepLink.link}');
+    //   }
+    // }
+
+    final initialUriString = await _appLinks.getInitialAppLinkString();
+    if (initialUriString != null) {
+      if (SigningRequestManager.isValidESRScheme(initialUriString)) {
+        add(DeeplinkEvent.incomingESRLink(initialUriString));
+      } else {
+        final uri = Uri.parse(initialUriString);
+        add(DeeplinkEvent.incomingFirebaseDeepLink(uri));
+      }
     }
+
+    _linkSubscription = _appLinks.stringLinkStream.listen((uriString) {
+      // Note: We must listen to strings, not Uris; Uri parsing loses case
+      // and ESR signing requests are case sensitive.
+      if (SigningRequestManager.isValidESRScheme(uriString)) {
+        print('>>> esr link detected: $uriString');
+        _debugShowMessage('esr link detected: $uriString');
+        add(DeeplinkEvent.incomingESRLink(uriString));
+      } else {
+        //_debugShowMessage('Not ESR: $uriString');
+        print('non esr link: $uriString');
+      }
+    }, onError: (error) {
+      print('link subscription error $error');
+    });
 
     FirebaseDynamicLinks.instance.onLink.listen((PendingDynamicLinkData dynamicLinkData) {
       LogHelper.d('received link: ${dynamicLinkData.link}');
-      add(DeeplinkEvent.incomingFirebaseDeepLink(dynamicLinkData.link));
+
+      if (!dynamicLinkData.link.isEsr()) {
+        _debugShowMessage('deep link: ${dynamicLinkData.link}');
+        add(DeeplinkEvent.incomingFirebaseDeepLink(dynamicLinkData.link));
+      } else {
+        _debugShowMessage('ESR link: ${dynamicLinkData.link}');
+      }
     }).onError((error) {
       LogHelper.e('Deep link error: $error');
     });
@@ -41,10 +89,7 @@ class DeeplinkBloc extends Bloc<DeeplinkEvent, DeeplinkState> {
   Future<void> _incomingFirebaseDeepLink(_IncomingFirebaseDeepLink event, Emitter<DeeplinkState> emit) async {
     /// fetch data from link.
     final queryParams = event.link.queryParameters;
-    if (queryParams.isNotEmpty &&
-        queryParams.containsKey('code') &&
-        queryParams.containsKey('chain') &&
-        queryParams.containsKey('dao')) {
+    if (queryParams.isNotEmpty && queryParams.containsKey('code') && queryParams.containsKey('chain')) {
       final code = queryParams['code']!;
       final chain = queryParams['chain']!;
       final dao = queryParams['dao']!;
@@ -72,5 +117,11 @@ class DeeplinkBloc extends Bloc<DeeplinkEvent, DeeplinkState> {
       print('error: ${result.asError!.error}');
       print(result.asError!.error);
     }
+  }
+}
+
+extension UriESR on Uri {
+  bool isEsr() {
+    return SigningRequestManager.isValidESRScheme(toString());
   }
 }

--- a/lib/ui/blocs/deeplink/deeplink_bloc.dart
+++ b/lib/ui/blocs/deeplink/deeplink_bloc.dart
@@ -95,7 +95,6 @@ class DeeplinkBloc extends Bloc<DeeplinkEvent, DeeplinkState> {
   }
 
   Future<void> _incomingESRLink(_IncomingESRLink event, Emitter<DeeplinkState> emit) async {
-    // final useCase = GetIt.I.get<ParseQRCodeUseCase>();
     final result = await _parseQRCodeUseCase.run(ParseESRLinkInput(esrLink: event.link));
     if (result.isValue) {
       emit(

--- a/lib/ui/blocs/deeplink/deeplink_bloc.dart
+++ b/lib/ui/blocs/deeplink/deeplink_bloc.dart
@@ -29,10 +29,6 @@ class DeeplinkBloc extends Bloc<DeeplinkEvent, DeeplinkState> {
     on<_ClearPageCommand>((_, emit) => emit(state.copyWith(command: null)));
   }
 
-  void _debugShowMessage(String message) {
-    Get.showSnackbar(GetSnackBar(message: message, duration: const Duration(seconds: 5)));
-  }
-
   Future<void> initDynamicLinks() async {
     // Handle initial firebase links - such as post install
     final PendingDynamicLinkData? initialDeepLink = await FirebaseDynamicLinks.instance.getInitialLink();

--- a/lib/ui/blocs/deeplink/deeplink_bloc.dart
+++ b/lib/ui/blocs/deeplink/deeplink_bloc.dart
@@ -99,8 +99,7 @@ class DeeplinkBloc extends Bloc<DeeplinkEvent, DeeplinkState> {
         ),
       );
     } else {
-      print('error: ${result.asError!.error}');
-      print(result.asError!.error);
+      LogHelper.e('error: ${result.asError!.error}');
     }
   }
 }

--- a/lib/ui/blocs/deeplink/deeplink_bloc.freezed.dart
+++ b/lib/ui/blocs/deeplink/deeplink_bloc.freezed.dart
@@ -19,18 +19,21 @@ mixin _$DeeplinkEvent {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(Uri link) incomingFirebaseDeepLink,
+    required TResult Function(String link) incomingESRLink,
     required TResult Function() clearPageCommand,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(Uri link)? incomingFirebaseDeepLink,
+    TResult? Function(String link)? incomingESRLink,
     TResult? Function()? clearPageCommand,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(Uri link)? incomingFirebaseDeepLink,
+    TResult Function(String link)? incomingESRLink,
     TResult Function()? clearPageCommand,
     required TResult orElse(),
   }) =>
@@ -39,6 +42,7 @@ mixin _$DeeplinkEvent {
   TResult map<TResult extends Object?>({
     required TResult Function(_IncomingFirebaseDeepLink value)
         incomingFirebaseDeepLink,
+    required TResult Function(_IncomingESRLink value) incomingESRLink,
     required TResult Function(_ClearPageCommand value) clearPageCommand,
   }) =>
       throw _privateConstructorUsedError;
@@ -46,12 +50,14 @@ mixin _$DeeplinkEvent {
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(_IncomingFirebaseDeepLink value)?
         incomingFirebaseDeepLink,
+    TResult? Function(_IncomingESRLink value)? incomingESRLink,
     TResult? Function(_ClearPageCommand value)? clearPageCommand,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_IncomingFirebaseDeepLink value)? incomingFirebaseDeepLink,
+    TResult Function(_IncomingESRLink value)? incomingESRLink,
     TResult Function(_ClearPageCommand value)? clearPageCommand,
     required TResult orElse(),
   }) =>
@@ -143,6 +149,7 @@ class _$_IncomingFirebaseDeepLink implements _IncomingFirebaseDeepLink {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(Uri link) incomingFirebaseDeepLink,
+    required TResult Function(String link) incomingESRLink,
     required TResult Function() clearPageCommand,
   }) {
     return incomingFirebaseDeepLink(link);
@@ -152,6 +159,7 @@ class _$_IncomingFirebaseDeepLink implements _IncomingFirebaseDeepLink {
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(Uri link)? incomingFirebaseDeepLink,
+    TResult? Function(String link)? incomingESRLink,
     TResult? Function()? clearPageCommand,
   }) {
     return incomingFirebaseDeepLink?.call(link);
@@ -161,6 +169,7 @@ class _$_IncomingFirebaseDeepLink implements _IncomingFirebaseDeepLink {
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(Uri link)? incomingFirebaseDeepLink,
+    TResult Function(String link)? incomingESRLink,
     TResult Function()? clearPageCommand,
     required TResult orElse(),
   }) {
@@ -175,6 +184,7 @@ class _$_IncomingFirebaseDeepLink implements _IncomingFirebaseDeepLink {
   TResult map<TResult extends Object?>({
     required TResult Function(_IncomingFirebaseDeepLink value)
         incomingFirebaseDeepLink,
+    required TResult Function(_IncomingESRLink value) incomingESRLink,
     required TResult Function(_ClearPageCommand value) clearPageCommand,
   }) {
     return incomingFirebaseDeepLink(this);
@@ -185,6 +195,7 @@ class _$_IncomingFirebaseDeepLink implements _IncomingFirebaseDeepLink {
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(_IncomingFirebaseDeepLink value)?
         incomingFirebaseDeepLink,
+    TResult? Function(_IncomingESRLink value)? incomingESRLink,
     TResult? Function(_ClearPageCommand value)? clearPageCommand,
   }) {
     return incomingFirebaseDeepLink?.call(this);
@@ -194,6 +205,7 @@ class _$_IncomingFirebaseDeepLink implements _IncomingFirebaseDeepLink {
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_IncomingFirebaseDeepLink value)? incomingFirebaseDeepLink,
+    TResult Function(_IncomingESRLink value)? incomingESRLink,
     TResult Function(_ClearPageCommand value)? clearPageCommand,
     required TResult orElse(),
   }) {
@@ -212,6 +224,147 @@ abstract class _IncomingFirebaseDeepLink implements DeeplinkEvent {
   @JsonKey(ignore: true)
   _$$_IncomingFirebaseDeepLinkCopyWith<_$_IncomingFirebaseDeepLink>
       get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$_IncomingESRLinkCopyWith<$Res> {
+  factory _$$_IncomingESRLinkCopyWith(
+          _$_IncomingESRLink value, $Res Function(_$_IncomingESRLink) then) =
+      __$$_IncomingESRLinkCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String link});
+}
+
+/// @nodoc
+class __$$_IncomingESRLinkCopyWithImpl<$Res>
+    extends _$DeeplinkEventCopyWithImpl<$Res, _$_IncomingESRLink>
+    implements _$$_IncomingESRLinkCopyWith<$Res> {
+  __$$_IncomingESRLinkCopyWithImpl(
+      _$_IncomingESRLink _value, $Res Function(_$_IncomingESRLink) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? link = null,
+  }) {
+    return _then(_$_IncomingESRLink(
+      null == link
+          ? _value.link
+          : link // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_IncomingESRLink implements _IncomingESRLink {
+  const _$_IncomingESRLink(this.link);
+
+  @override
+  final String link;
+
+  @override
+  String toString() {
+    return 'DeeplinkEvent.incomingESRLink(link: $link)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_IncomingESRLink &&
+            (identical(other.link, link) || other.link == link));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, link);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_IncomingESRLinkCopyWith<_$_IncomingESRLink> get copyWith =>
+      __$$_IncomingESRLinkCopyWithImpl<_$_IncomingESRLink>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(Uri link) incomingFirebaseDeepLink,
+    required TResult Function(String link) incomingESRLink,
+    required TResult Function() clearPageCommand,
+  }) {
+    return incomingESRLink(link);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(Uri link)? incomingFirebaseDeepLink,
+    TResult? Function(String link)? incomingESRLink,
+    TResult? Function()? clearPageCommand,
+  }) {
+    return incomingESRLink?.call(link);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(Uri link)? incomingFirebaseDeepLink,
+    TResult Function(String link)? incomingESRLink,
+    TResult Function()? clearPageCommand,
+    required TResult orElse(),
+  }) {
+    if (incomingESRLink != null) {
+      return incomingESRLink(link);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_IncomingFirebaseDeepLink value)
+        incomingFirebaseDeepLink,
+    required TResult Function(_IncomingESRLink value) incomingESRLink,
+    required TResult Function(_ClearPageCommand value) clearPageCommand,
+  }) {
+    return incomingESRLink(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_IncomingFirebaseDeepLink value)?
+        incomingFirebaseDeepLink,
+    TResult? Function(_IncomingESRLink value)? incomingESRLink,
+    TResult? Function(_ClearPageCommand value)? clearPageCommand,
+  }) {
+    return incomingESRLink?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_IncomingFirebaseDeepLink value)? incomingFirebaseDeepLink,
+    TResult Function(_IncomingESRLink value)? incomingESRLink,
+    TResult Function(_ClearPageCommand value)? clearPageCommand,
+    required TResult orElse(),
+  }) {
+    if (incomingESRLink != null) {
+      return incomingESRLink(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _IncomingESRLink implements DeeplinkEvent {
+  const factory _IncomingESRLink(final String link) = _$_IncomingESRLink;
+
+  String get link;
+  @JsonKey(ignore: true)
+  _$$_IncomingESRLinkCopyWith<_$_IncomingESRLink> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -253,6 +406,7 @@ class _$_ClearPageCommand implements _ClearPageCommand {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(Uri link) incomingFirebaseDeepLink,
+    required TResult Function(String link) incomingESRLink,
     required TResult Function() clearPageCommand,
   }) {
     return clearPageCommand();
@@ -262,6 +416,7 @@ class _$_ClearPageCommand implements _ClearPageCommand {
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(Uri link)? incomingFirebaseDeepLink,
+    TResult? Function(String link)? incomingESRLink,
     TResult? Function()? clearPageCommand,
   }) {
     return clearPageCommand?.call();
@@ -271,6 +426,7 @@ class _$_ClearPageCommand implements _ClearPageCommand {
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(Uri link)? incomingFirebaseDeepLink,
+    TResult Function(String link)? incomingESRLink,
     TResult Function()? clearPageCommand,
     required TResult orElse(),
   }) {
@@ -285,6 +441,7 @@ class _$_ClearPageCommand implements _ClearPageCommand {
   TResult map<TResult extends Object?>({
     required TResult Function(_IncomingFirebaseDeepLink value)
         incomingFirebaseDeepLink,
+    required TResult Function(_IncomingESRLink value) incomingESRLink,
     required TResult Function(_ClearPageCommand value) clearPageCommand,
   }) {
     return clearPageCommand(this);
@@ -295,6 +452,7 @@ class _$_ClearPageCommand implements _ClearPageCommand {
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(_IncomingFirebaseDeepLink value)?
         incomingFirebaseDeepLink,
+    TResult? Function(_IncomingESRLink value)? incomingESRLink,
     TResult? Function(_ClearPageCommand value)? clearPageCommand,
   }) {
     return clearPageCommand?.call(this);
@@ -304,6 +462,7 @@ class _$_ClearPageCommand implements _ClearPageCommand {
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_IncomingFirebaseDeepLink value)? incomingFirebaseDeepLink,
+    TResult Function(_IncomingESRLink value)? incomingESRLink,
     TResult Function(_ClearPageCommand value)? clearPageCommand,
     required TResult orElse(),
   }) {
@@ -476,16 +635,20 @@ mixin _$PageCommand {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() navigateToCreateAccount,
+    required TResult Function(ScanQrCodeResultData data)
+        navigateToSignTransaction,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? navigateToCreateAccount,
+    TResult? Function(ScanQrCodeResultData data)? navigateToSignTransaction,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? navigateToCreateAccount,
+    TResult Function(ScanQrCodeResultData data)? navigateToSignTransaction,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -493,16 +656,22 @@ mixin _$PageCommand {
   TResult map<TResult extends Object?>({
     required TResult Function(_NavigateToCreateAccount value)
         navigateToCreateAccount,
+    required TResult Function(_ESRLinkNavigateToSignTransaction value)
+        navigateToSignTransaction,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(_NavigateToCreateAccount value)? navigateToCreateAccount,
+    TResult? Function(_ESRLinkNavigateToSignTransaction value)?
+        navigateToSignTransaction,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_NavigateToCreateAccount value)? navigateToCreateAccount,
+    TResult Function(_ESRLinkNavigateToSignTransaction value)?
+        navigateToSignTransaction,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -566,6 +735,8 @@ class _$_NavigateToCreateAccount implements _NavigateToCreateAccount {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() navigateToCreateAccount,
+    required TResult Function(ScanQrCodeResultData data)
+        navigateToSignTransaction,
   }) {
     return navigateToCreateAccount();
   }
@@ -574,6 +745,7 @@ class _$_NavigateToCreateAccount implements _NavigateToCreateAccount {
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? navigateToCreateAccount,
+    TResult? Function(ScanQrCodeResultData data)? navigateToSignTransaction,
   }) {
     return navigateToCreateAccount?.call();
   }
@@ -582,6 +754,7 @@ class _$_NavigateToCreateAccount implements _NavigateToCreateAccount {
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? navigateToCreateAccount,
+    TResult Function(ScanQrCodeResultData data)? navigateToSignTransaction,
     required TResult orElse(),
   }) {
     if (navigateToCreateAccount != null) {
@@ -595,6 +768,8 @@ class _$_NavigateToCreateAccount implements _NavigateToCreateAccount {
   TResult map<TResult extends Object?>({
     required TResult Function(_NavigateToCreateAccount value)
         navigateToCreateAccount,
+    required TResult Function(_ESRLinkNavigateToSignTransaction value)
+        navigateToSignTransaction,
   }) {
     return navigateToCreateAccount(this);
   }
@@ -603,6 +778,8 @@ class _$_NavigateToCreateAccount implements _NavigateToCreateAccount {
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(_NavigateToCreateAccount value)? navigateToCreateAccount,
+    TResult? Function(_ESRLinkNavigateToSignTransaction value)?
+        navigateToSignTransaction,
   }) {
     return navigateToCreateAccount?.call(this);
   }
@@ -611,6 +788,8 @@ class _$_NavigateToCreateAccount implements _NavigateToCreateAccount {
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_NavigateToCreateAccount value)? navigateToCreateAccount,
+    TResult Function(_ESRLinkNavigateToSignTransaction value)?
+        navigateToSignTransaction,
     required TResult orElse(),
   }) {
     if (navigateToCreateAccount != null) {
@@ -622,4 +801,149 @@ class _$_NavigateToCreateAccount implements _NavigateToCreateAccount {
 
 abstract class _NavigateToCreateAccount implements PageCommand {
   const factory _NavigateToCreateAccount() = _$_NavigateToCreateAccount;
+}
+
+/// @nodoc
+abstract class _$$_ESRLinkNavigateToSignTransactionCopyWith<$Res> {
+  factory _$$_ESRLinkNavigateToSignTransactionCopyWith(
+          _$_ESRLinkNavigateToSignTransaction value,
+          $Res Function(_$_ESRLinkNavigateToSignTransaction) then) =
+      __$$_ESRLinkNavigateToSignTransactionCopyWithImpl<$Res>;
+  @useResult
+  $Res call({ScanQrCodeResultData data});
+}
+
+/// @nodoc
+class __$$_ESRLinkNavigateToSignTransactionCopyWithImpl<$Res>
+    extends _$PageCommandCopyWithImpl<$Res, _$_ESRLinkNavigateToSignTransaction>
+    implements _$$_ESRLinkNavigateToSignTransactionCopyWith<$Res> {
+  __$$_ESRLinkNavigateToSignTransactionCopyWithImpl(
+      _$_ESRLinkNavigateToSignTransaction _value,
+      $Res Function(_$_ESRLinkNavigateToSignTransaction) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? data = null,
+  }) {
+    return _then(_$_ESRLinkNavigateToSignTransaction(
+      null == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as ScanQrCodeResultData,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_ESRLinkNavigateToSignTransaction
+    implements _ESRLinkNavigateToSignTransaction {
+  const _$_ESRLinkNavigateToSignTransaction(this.data);
+
+  @override
+  final ScanQrCodeResultData data;
+
+  @override
+  String toString() {
+    return 'PageCommand.navigateToSignTransaction(data: $data)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_ESRLinkNavigateToSignTransaction &&
+            (identical(other.data, data) || other.data == data));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, data);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_ESRLinkNavigateToSignTransactionCopyWith<
+          _$_ESRLinkNavigateToSignTransaction>
+      get copyWith => __$$_ESRLinkNavigateToSignTransactionCopyWithImpl<
+          _$_ESRLinkNavigateToSignTransaction>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() navigateToCreateAccount,
+    required TResult Function(ScanQrCodeResultData data)
+        navigateToSignTransaction,
+  }) {
+    return navigateToSignTransaction(data);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? navigateToCreateAccount,
+    TResult? Function(ScanQrCodeResultData data)? navigateToSignTransaction,
+  }) {
+    return navigateToSignTransaction?.call(data);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? navigateToCreateAccount,
+    TResult Function(ScanQrCodeResultData data)? navigateToSignTransaction,
+    required TResult orElse(),
+  }) {
+    if (navigateToSignTransaction != null) {
+      return navigateToSignTransaction(data);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_NavigateToCreateAccount value)
+        navigateToCreateAccount,
+    required TResult Function(_ESRLinkNavigateToSignTransaction value)
+        navigateToSignTransaction,
+  }) {
+    return navigateToSignTransaction(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_NavigateToCreateAccount value)? navigateToCreateAccount,
+    TResult? Function(_ESRLinkNavigateToSignTransaction value)?
+        navigateToSignTransaction,
+  }) {
+    return navigateToSignTransaction?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_NavigateToCreateAccount value)? navigateToCreateAccount,
+    TResult Function(_ESRLinkNavigateToSignTransaction value)?
+        navigateToSignTransaction,
+    required TResult orElse(),
+  }) {
+    if (navigateToSignTransaction != null) {
+      return navigateToSignTransaction(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _ESRLinkNavigateToSignTransaction implements PageCommand {
+  const factory _ESRLinkNavigateToSignTransaction(
+      final ScanQrCodeResultData data) = _$_ESRLinkNavigateToSignTransaction;
+
+  ScanQrCodeResultData get data;
+  @JsonKey(ignore: true)
+  _$$_ESRLinkNavigateToSignTransactionCopyWith<
+          _$_ESRLinkNavigateToSignTransaction>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/ui/blocs/deeplink/deeplink_event.dart
+++ b/lib/ui/blocs/deeplink/deeplink_event.dart
@@ -3,5 +3,6 @@ part of 'deeplink_bloc.dart';
 @freezed
 class DeeplinkEvent with _$DeeplinkEvent {
   const factory DeeplinkEvent.incomingFirebaseDeepLink(Uri link) = _IncomingFirebaseDeepLink;
+  const factory DeeplinkEvent.incomingESRLink(String link) = _IncomingESRLink;
   const factory DeeplinkEvent.clearPageCommand() = _ClearPageCommand;
 }

--- a/lib/ui/blocs/deeplink/deeplink_state.dart
+++ b/lib/ui/blocs/deeplink/deeplink_state.dart
@@ -11,7 +11,7 @@ class DeeplinkState with _$DeeplinkState {
 class InviteLinkData {
   final String code;
   final String chain;
-  final String dao;
+  final String? dao;
 
-  InviteLinkData({required this.code, required this.chain, required this.dao});
+  InviteLinkData({required this.code, required this.chain, this.dao});
 }

--- a/lib/ui/blocs/deeplink/page_command.dart
+++ b/lib/ui/blocs/deeplink/page_command.dart
@@ -3,4 +3,5 @@ part of 'deeplink_bloc.dart';
 @freezed
 class PageCommand with _$PageCommand {
   const factory PageCommand.navigateToCreateAccount() = _NavigateToCreateAccount;
+  const factory PageCommand.navigateToSignTransaction(ScanQrCodeResultData data) = _ESRLinkNavigateToSignTransaction;
 }

--- a/lib/ui/blocs/push_notifications/push_notifications_bloc.dart
+++ b/lib/ui/blocs/push_notifications/push_notifications_bloc.dart
@@ -39,7 +39,7 @@ class PushNotificationsBloc extends Bloc<PushNotificationsEvent, PushNotificatio
     if (message.data.containsKey('incoming_transaction')) {
       final String? incomingTransaction = message.notification?.body;
       final result = await incomingTransaction
-          ?.let((it) async => parseQRCodeUseCase.run(ParseQrCodeInput(scanResult: incomingTransaction)));
+          ?.let((it) async => parseQRCodeUseCase.run(ParseESRLinkInput(esrLink: incomingTransaction)));
 
       if (result?.isValue == true) {
         final ScanQrCodeResultData value = result!.asValue!.value;

--- a/lib/ui/home_page/interactor/home_bloc.dart
+++ b/lib/ui/home_page/interactor/home_bloc.dart
@@ -33,7 +33,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     }
 
     emit(state.copyWith(isLoading: true));
-    final result = await _parseQRCodeUseCase.run(ParseQrCodeInput(scanResult: event.value));
+    final result = await _parseQRCodeUseCase.run(ParseESRLinkInput(esrLink: event.value));
 
     if (result.isValue) {
       final ScanQrCodeResultData value = result.asValue!.value;

--- a/lib/ui/home_page/usecases/parse_qr_code_use_case.dart
+++ b/lib/ui/home_page/usecases/parse_qr_code_use_case.dart
@@ -8,15 +8,15 @@ import 'package:hypha_wallet/core/shared_preferences/hypha_shared_prefs.dart';
 import 'package:hypha_wallet/ui/architecture/interactor/base_usecase.dart';
 import 'package:hypha_wallet/ui/architecture/result/result.dart' as HResult;
 
-class ParseQRCodeUseCase extends InputUseCase<HResult.Result<ScanQrCodeResultData, HyphaError>, ParseQrCodeInput> {
+class ParseQRCodeUseCase extends InputUseCase<HResult.Result<ScanQrCodeResultData, HyphaError>, ParseESRLinkInput> {
   final HyphaSharedPrefs _appSharedPrefs;
   ParseQRCodeUseCase(this._appSharedPrefs);
 
   @override
-  Future<HResult.Result<ScanQrCodeResultData, HyphaError>> run(ParseQrCodeInput input) async {
+  Future<HResult.Result<ScanQrCodeResultData, HyphaError>> run(ParseESRLinkInput input) async {
     final UserProfileData? userData = await _appSharedPrefs.getUserProfileData();
     final qrCodeValidationResult =
-        await _validateQrCode(accountName: userData?.accountName ?? '', scanResult: input.scanResult);
+        await _validateQrCode(accountName: userData?.accountName ?? '', scanResult: input.esrLink);
 
     if (qrCodeValidationResult.isValue) {
       return HResult.Result.value(qrCodeValidationResult.asValue!.value);
@@ -49,8 +49,8 @@ Future<Result<ScanQrCodeResultData>> _validateQrCode({required String scanResult
   }
 }
 
-class ParseQrCodeInput {
-  final String scanResult;
+class ParseESRLinkInput {
+  final String esrLink;
 
-  ParseQrCodeInput({required this.scanResult});
+  ParseESRLinkInput({required this.esrLink});
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import app_links
 import cloud_firestore
 import firebase_core
 import firebase_crashlytics
@@ -18,6 +19,7 @@ import shared_preferences_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseCrashlyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCrashlyticsPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.2.0"
+  app_links:
+    dependency: "direct main"
+    description:
+      name: app_links
+      sha256: d572dcdff49c4cfcfa6f315e2683e518ec6eb54e084d01e51d9631a4dcc1b5e8
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.2"
   archive:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+16
+version: 1.0.0+17
 
 environment:
   sdk: '>=2.18.5 <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -123,6 +123,7 @@ dependencies:
 
   # Amazon stuff for profile... Weak sauce
   amazon_cognito_identity_dart_2: ^3.2.0
+  app_links: ^3.4.2
 
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+17
+version: 1.0.1+18
 
 environment:
   sdk: '>=2.18.5 <3.0.0'

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,12 +6,15 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <app_links/app_links_plugin_c_api.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  AppLinksPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  app_links
   flutter_secure_storage_windows
   permission_handler_windows
   share_plus


### PR DESCRIPTION
I kept deep links exactly as before

Only ESR links are also handled. 

I feel this is safest to make sure the post-install app store link still works, but we can only test that once we're live.

I tested 4 different scenarios
- Cold start with ESR
- Cold start with firebase link
- ESR when app is in the background but running
- Deep link when app in background but running

All 4 work - Cold start with firebase link has an issue on iPhone simulator, but works on device - tested in build 18 on Testflight. 

Test URLs

ESR
```
esr://gmNgYmBYlmzC9MoglIFhB9frlxK9jIwMEMAEpQVhAhyWppZGhhZGRowJGSUlBVb6-okFmboFiZW5qXklehmVBRmJeqmJRSUZ-iVFiXnFicklmfl59qWZKbaGiUlJySbmybqpKUbJuqaWFqm6FqlJJrqpSWYpaeYWiYZJSeZqJRXxQKXV1SUVtbUMAA
```

Firebase (not a valid invite code BTW so this won't actually be able to create an account)
```
https://hyphawallet.page.link/?link=https://hypha.earth/invite?code%3D12345abcde%26chain%3Dtelos%26dao%3D219987%26env%3Ddev&apn=earth.hypha.wallet.hypha_wallet&isi=1659926348&ibi=earth.hypha.wallet.hyphaWallet

```