### PR TITLE
save device token on auth change

### DIFF
--- a/lib/ui/blocs/authentication/authentication_bloc.dart
+++ b/lib/ui/blocs/authentication/authentication_bloc.dart
@@ -115,8 +115,13 @@ class AuthenticationBloc extends Bloc<AuthenticationEvent, AuthenticationState> 
     await state.userProfileData?.accountName.let((it) => _authRepository.logOut(it));
   }
 
-  FutureOr<void> _onAuthenticatedDataChanged(_OnAuthenticatedDataChanged event, Emitter<AuthenticationState> emit) {
+  FutureOr<void> _onAuthenticatedDataChanged(
+      _OnAuthenticatedDataChanged event, Emitter<AuthenticationState> emit) async {
     emit(state.copyWith(userProfileData: event.data));
+    final token = await _firebasePushNotificationsService.getDeviceToken();
+    if (token != null) {
+      add(_OnFCMTokenChanged(token));
+    }
   }
 
   FutureOr<void> _onFCMTokenChanged(_OnFCMTokenChanged event, Emitter<AuthenticationState> emit) {


### PR DESCRIPTION

Problem: deviceTokens was not being set reliably
Fix: Setting it any time auth data changes, covering login and app start. 

=====

Not sure this is the best place to do it - but in fact we need to store the device token any time the app starts, since it may start on a new phone for example. 

Also when authentication changes, we may have a new user, etc. 

We should probably check if the auth token is already set, and not do it if not needed - but maybe firebase does that internally? 

=====

Also we need to store account names with chain ID... 

example illum1nation:eos

Since account names are only unique to a single chain. We can make that change when we support multiple accounts.