### PR TITLE
Fix for nullable parameter

### DIFF
--- a/lib/core/crypto/eosdart/src/serialize.dart
+++ b/lib/core/crypto/eosdart/src/serialize.dart
@@ -973,7 +973,7 @@ deserializeArray(Type self, SerialBuffer buffer, {SerializerState? state, allowE
   return result;
 }
 
-serializeOptional(Type self, SerialBuffer buffer, Object data, {SerializerState? state, allowExtensions = true}) {
+serializeOptional(Type self, SerialBuffer buffer, Object? data, {SerializerState? state, allowExtensions = true}) {
   if (state == null) state = SerializerState();
   if (data == null) {
     buffer.push([0]);


### PR DESCRIPTION
fixed the parameter so it can be null

### Background

EOSIO allows optional values 

setdaosetting has an optional string - denoted as type "string?" in the ABI of the contract

This caused Hypha Wallet to fail since the object was not set to nullable in the parameters

We introduced this bug when moving the entire crypto package eos_dart to be null safe

### Fix
parameter needs to be nullable

I was checking this against the EOSJS JavaScript package which eosdart is based on.

### Tested
Yes

### Testcase
![image](https://github.com/hypha-dao/hypha_wallet/assets/65412/fbdfa540-003c-46bf-a52a-0ef781a8a143)

Note that the action will still throw an exception since it has the wrong actor / permission, but it now throws an action/permission exception rather than a serialization exception. 

### Error before bugfix
```
flutter: mapEosError: type 'Null' is not a subtype of type 'Object' of 'data'
flutter: stack: #0      _TypeError._throwNew (dart:core-patch/errors_patch.dart:105:68)
#1      serializeStruct
#2      EOSClient._serializeActionData
#3      EOSClient._serializeActions
<asynchronous suspension>
#4      EOSClient.getRequiredKeys
<asynchronous suspension>
#5      EOSClient._pushTransactionArgs
<asynchronous suspension>
#6      EOSClient.pushTransaction
<asynchronous suspension>
#7      SignTransactionUseCase.run
<asynchronous suspension>
#8      SignTransactionBloc._onUserSlideCompleted
<asynchronous suspension>
#9      Bloc.on.<anonymous closure>.handleEvent
<asynchronous suspension>
```