### PR TITLE
[DRAFT] Full network support

### DIFF
--- a/lib/core/crypto/dart_esr/src/signing_request_manager.dart
+++ b/lib/core/crypto/dart_esr/src/signing_request_manager.dart
@@ -812,7 +812,6 @@ extension HyphaSigningRequestManager on SigningRequestManager {
   static Network resolveNetwork(List<dynamic> chainId) {
     if (chainId[0] == 'chain_alias') {
       // chain_alias officially only supports EOS mainnet, and Telos mainnet, as 1, and 2.
-      // Also supports others but we don't suppor those
       if (chainId[1] == 1) {
         return Network.eos;
       } else if (chainId[1] == 2) {

--- a/lib/core/crypto/dart_esr/src/signing_request_manager.dart
+++ b/lib/core/crypto/dart_esr/src/signing_request_manager.dart
@@ -812,6 +812,7 @@ extension HyphaSigningRequestManager on SigningRequestManager {
   static Network resolveNetwork(List<dynamic> chainId) {
     if (chainId[0] == 'chain_alias') {
       // chain_alias officially only supports EOS mainnet, and Telos mainnet, as 1, and 2.
+      // Also supports others but we don't suppor those
       if (chainId[1] == 1) {
         return Network.eos;
       } else if (chainId[1] == 2) {

--- a/lib/core/di/services_module.dart
+++ b/lib/core/di/services_module.dart
@@ -7,6 +7,8 @@ Future<void> _registerServicesModule() async {
 
   /// DIO
   _registerLazySingleton(() => Dio());
+
+  // TODO: Only remaining hard-coded reference to Telos - I guess we can't create NetworkingManager with base URL since the base URL depends on the network?
   _registerLazySingleton(() => NetworkingManager(_getIt<RemoteConfigService>().baseUrl(network: Network.telos)));
 
   /// Secure Storage

--- a/lib/core/di/services_module.dart
+++ b/lib/core/di/services_module.dart
@@ -8,7 +8,7 @@ Future<void> _registerServicesModule() async {
   /// DIO
   _registerLazySingleton(() => Dio());
 
-  // TODO: Only remaining hard-coded reference to Telos - I guess we can't create NetworkingManager with base URL since the base URL depends on the network?
+  // TODO(n13): Only remaining hard-coded reference to Telos - I guess we can't create NetworkingManager with base URL since the base URL depends on the network?
   _registerLazySingleton(() => NetworkingManager(_getIt<RemoteConfigService>().baseUrl(network: Network.telos)));
 
   /// Secure Storage

--- a/lib/core/di/services_module.dart
+++ b/lib/core/di/services_module.dart
@@ -7,7 +7,7 @@ Future<void> _registerServicesModule() async {
 
   /// DIO
   _registerLazySingleton(() => Dio());
-  _registerLazySingleton(() => NetworkingManager(_getIt<RemoteConfigService>().baseUrl()));
+  _registerLazySingleton(() => NetworkingManager(_getIt<RemoteConfigService>().baseUrl(network: Network.telos)));
 
   /// Secure Storage
   _registerLazySingleton(() => const FlutterSecureStorage());

--- a/lib/core/network/api/services/remote_config_service.dart
+++ b/lib/core/network/api/services/remote_config_service.dart
@@ -17,8 +17,6 @@ enum Network {
   }
 }
 
-// const Network _defaultNetwork = Network.telos;
-
 /// Encapsulates everything to do with remote configuration
 class RemoteConfigService {
   static Future<RemoteConfigService> initialized() async {

--- a/lib/core/network/api/services/remote_config_service.dart
+++ b/lib/core/network/api/services/remote_config_service.dart
@@ -17,7 +17,7 @@ enum Network {
   }
 }
 
-const Network _defaultNetwork = Network.telos;
+// const Network _defaultNetwork = Network.telos;
 
 /// Encapsulates everything to do with remote configuration
 class RemoteConfigService {
@@ -32,13 +32,13 @@ class RemoteConfigService {
     return json.decode(FirebaseRemoteConfig.instance.getValue(param).asString());
   }
 
-  Map<String, dynamic> _pppService({Network? network}) {
-    network = network ?? _defaultNetwork;
+  Map<String, dynamic> _pppService({required Network network}) {
+    network = network;
     return _getMap('profileService')[network.name];
   }
 
-  Map<String, dynamic> _getNetworkConfig({Network? network}) {
-    network = network ?? _defaultNetwork;
+  Map<String, dynamic> _getNetworkConfig({required Network network}) {
+    network = network;
     final conf = _getMap('networks');
     final networkFromConfig = conf[network.name];
     if (networkFromConfig == null) {
@@ -49,7 +49,7 @@ class RemoteConfigService {
 
   // base url - read URL
   // network: default is Telos mainnet
-  String baseUrl({Network? network}) {
+  String baseUrl({required Network network}) {
     final networkConfig = _getNetworkConfig(network: network);
     final endpoint = networkConfig['endpoint'];
     return endpoint;
@@ -69,27 +69,27 @@ class RemoteConfigService {
     return endpoint;
   }
 
-  String loginContract({Network? network}) {
+  String loginContract({required Network network}) {
     final networkConfig = _getNetworkConfig(network: network);
     return networkConfig['loginContract'];
   }
 
-  String loginAction({Network? network}) {
+  String loginAction({required Network network}) {
     final networkConfig = _getNetworkConfig(network: network);
     return networkConfig['loginAction'];
   }
 
-  String inviteContract({Network? network}) {
+  String inviteContract({required Network network}) {
     final networkConfig = _getNetworkConfig(network: network);
     return networkConfig['inviteContract'];
   }
 
-  String payCpuContract({Network? network}) {
+  String payCpuContract({required Network network}) {
     final networkConfig = _getNetworkConfig(network: network);
     return networkConfig['payCpuContract'];
   }
 
-  String daoContract({Network? network}) {
+  String daoContract({required Network network}) {
     final networkConfig = _getNetworkConfig(network: network);
     return networkConfig['daoContract'];
   }
@@ -104,23 +104,23 @@ class RemoteConfigService {
   String get accountCreatorEndpoint => FirebaseRemoteConfig.instance.getString('accountCreatorEndpoint');
 
   // PPP Service AWS
-  String get awsProfileServiceEndpoint => _pppService()['awsProfileServiceEndpoint'];
+  String awsProfileServiceEndpoint(Network network) => _pppService(network: network)['awsProfileServiceEndpoint'];
 
-  String get pppEndpoint => _pppService()['awsProfileServiceEndpoint'];
+  String pppEndpoint(Network network) => _pppService(network: network)['awsProfileServiceEndpoint'];
 
-  String get identityPoolId => _pppService()['identityPoolId'];
+  String identityPoolId(Network network) => _pppService(network: network)['identityPoolId'];
 
-  String get userPoolId => _pppService()['userPoolId'];
+  String userPoolId(Network network) => _pppService(network: network)['userPoolId'];
 
-  String get clientId => _pppService()['clientId'];
+  String clientId(Network network) => _pppService(network: network)['clientId'];
 
-  String get pppOriginAppId => _pppService()['pppOriginAppId'];
+  String pppOriginAppId(Network network) => _pppService(network: network)['pppOriginAppId'];
 
-  String get pppRegion => _pppService()['region'];
+  String pppRegion(Network network) => _pppService(network: network)['region'];
 
-  String get pppS3Region => _pppService()['s3Region'];
+  String pppS3Region(Network network) => _pppService(network: network)['s3Region'];
 
-  String get pppS3Bucket => _pppService()['s3Bucket'];
+  String pppS3Bucket(Network network) => _pppService(network: network)['s3Bucket'];
 
   // TODO(NIK): find the best endpoints for EOS
   Future<void> setDefaults() async {

--- a/lib/core/network/repository/auth_repository.dart
+++ b/lib/core/network/repository/auth_repository.dart
@@ -67,18 +67,25 @@ class AuthRepository {
         publicKey: userAuthData.publicKey.toString(),
       );
 
+      final network = Network.fromString(inviteLinkData.chain);
+
       _saveUserData(
         UserProfileData(
           accountName: accountName,
           userName: userName,
-          network: Network.fromString(inviteLinkData.chain),
+          network: network,
         ),
         userAuthData,
         false,
       );
 
       print('create ppp account for $accountName with image ${image?.path}');
-      await _uploadRepository.scheduleUpload(accountName: accountName, userName: userName, fileName: image?.path);
+      await _uploadRepository.scheduleUpload(
+        accountName: accountName,
+        network: network,
+        userName: userName,
+        fileName: image?.path,
+      );
       unawaited(_uploadRepository.start());
 
       return true;

--- a/lib/ui/onboarding/import_account/usecases/find_account_use_case.dart
+++ b/lib/ui/onboarding/import_account/usecases/find_account_use_case.dart
@@ -10,7 +10,7 @@ class FindAccountsUseCase extends InputUseCase<Result<Iterable<UserProfileData>,
   final RemoteConfigService remoteConfigService;
   final GetUserProfilesFromAccountsUseCase getUserProfilesFromAccountsUseCase;
 
-  FindAccountsUseCase( this.remoteConfigService, this.getUserProfilesFromAccountsUseCase);
+  FindAccountsUseCase(this.remoteConfigService, this.getUserProfilesFromAccountsUseCase);
 
   @override
   Future<Result<Iterable<UserProfileData>, HyphaError>> run(String input) async {
@@ -29,17 +29,43 @@ class FindAccountsUseCase extends InputUseCase<Result<Iterable<UserProfileData>,
       version: 'v1',
     );
 
-    final results = await Future.wait([eosClient.getKeyAccounts(input), telosClient.getKeyAccounts(input)]);
+    final telosTestnetClient = EOSClient(
+      baseUrl: remoteConfigService.baseUrl(network: Network.telosTestnet),
+      privateKeys: [],
+      version: 'v1',
+    );
+
+    final eosTestnetClient = EOSClient(
+      baseUrl: remoteConfigService.baseUrl(network: Network.eosTestnet),
+      privateKeys: [],
+      version: 'v1',
+    );
+
+    final results = await Future.wait([
+      eosClient.getKeyAccounts(input),
+      telosClient.getKeyAccounts(input),
+      telosTestnetClient.getKeyAccounts(input),
+      eosTestnetClient.getKeyAccounts(input)
+    ]);
     final eosResult = results[0];
     final telosResult = results[1];
+    final telosTestnetResult = results[2];
+    final eosTestnetResult = results[3];
 
     final Map<Network, List<String>> data = {};
 
     // AccountNames? data;
     if (eosResult.isValue) {
       data.putIfAbsent(Network.eos, () => eosResult.asValue!.value.accountNames);
-    } else if (telosResult.isValue) {
+    }
+    if (telosResult.isValue) {
       data.putIfAbsent(Network.telos, () => telosResult.asValue!.value.accountNames);
+    }
+    if (telosTestnetResult.isValue) {
+      data.putIfAbsent(Network.telosTestnet, () => telosTestnetResult.asValue!.value.accountNames);
+    }
+    if (eosTestnetResult.isValue) {
+      data.putIfAbsent(Network.eosTestnet, () => eosTestnetResult.asValue!.value.accountNames);
     }
 
     if (data.isNotEmpty) {

--- a/lib/ui/onboarding/import_account/usecases/find_account_use_case.dart
+++ b/lib/ui/onboarding/import_account/usecases/find_account_use_case.dart
@@ -29,43 +29,17 @@ class FindAccountsUseCase extends InputUseCase<Result<Iterable<UserProfileData>,
       version: 'v1',
     );
 
-    final telosTestnetClient = EOSClient(
-      baseUrl: remoteConfigService.baseUrl(network: Network.telosTestnet),
-      privateKeys: [],
-      version: 'v1',
-    );
-
-    final eosTestnetClient = EOSClient(
-      baseUrl: remoteConfigService.baseUrl(network: Network.eosTestnet),
-      privateKeys: [],
-      version: 'v1',
-    );
-
-    final results = await Future.wait([
-      eosClient.getKeyAccounts(input),
-      telosClient.getKeyAccounts(input),
-      telosTestnetClient.getKeyAccounts(input),
-      eosTestnetClient.getKeyAccounts(input)
-    ]);
+    final results = await Future.wait([eosClient.getKeyAccounts(input), telosClient.getKeyAccounts(input)]);
     final eosResult = results[0];
     final telosResult = results[1];
-    final telosTestnetResult = results[2];
-    final eosTestnetResult = results[3];
 
     final Map<Network, List<String>> data = {};
 
     // AccountNames? data;
     if (eosResult.isValue) {
       data.putIfAbsent(Network.eos, () => eosResult.asValue!.value.accountNames);
-    }
-    if (telosResult.isValue) {
+    } else if (telosResult.isValue) {
       data.putIfAbsent(Network.telos, () => telosResult.asValue!.value.accountNames);
-    }
-    if (telosTestnetResult.isValue) {
-      data.putIfAbsent(Network.telosTestnet, () => telosTestnetResult.asValue!.value.accountNames);
-    }
-    if (eosTestnetResult.isValue) {
-      data.putIfAbsent(Network.eosTestnet, () => eosTestnetResult.asValue!.value.accountNames);
     }
 
     if (data.isNotEmpty) {

--- a/lib/ui/profile/interactor/profile_bloc.dart
+++ b/lib/ui/profile/interactor/profile_bloc.dart
@@ -76,7 +76,8 @@ class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
 
   FutureOr<void> _setName(_SetName event, Emitter<ProfileState> emit) async {
     emit(state.copyWith(showUpdateBioLoading: true));
-    final result = await _setNameUseCase.run(accountName: state.profileData!.account, name: event.name);
+    final result = await _setNameUseCase.run(
+        accountName: state.profileData!.account, name: event.name, network: state.profileData!.network);
     if (result.isValue) {
       emit(
         state.copyWith(
@@ -95,7 +96,8 @@ class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
   FutureOr<void> _setBio(_SetBio event, Emitter<ProfileState> emit) async {
     emit(state.copyWith(showUpdateBioLoading: true));
     final result = await _setBioUseCase.run(
-      SetBioUseCaseInput(accountName: state.profileData!.account, profileBio: event.bio),
+      SetBioUseCaseInput(
+          accountName: state.profileData!.account, profileBio: event.bio, network: state.profileData!.network),
     );
     if (result.isValue) {
       emit(
@@ -114,7 +116,7 @@ class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
 
   FutureOr<void> _setAvatarImage(_SetAvatarImage event, Emitter<ProfileState> emit) async {
     emit(state.copyWith(showUpdateImageLoading: true));
-    final result = await _setImageUseCase.run(event.image, state.profileData!.account);
+    final result = await _setImageUseCase.run(event.image, state.profileData!.account, state.profileData!.network);
     final userData = _authRepository.authDataOrCrash;
 
     if (result.isValue) {
@@ -137,7 +139,7 @@ class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
 
   FutureOr<void> _onRemoveImageTapped(_OnRemoveImageTapped event, Emitter<ProfileState> emit) async {
     emit(state.copyWith(showUpdateImageLoading: true));
-    final result = await _removeAvatarUseCase.run(state.profileData!.account);
+    final result = await _removeAvatarUseCase.run(state.profileData!.account, state.profileData!.network);
     if (result.isValue) {
       emit(
         state.copyWith(

--- a/lib/ui/profile/usecases/initialize_profile_use_case.dart
+++ b/lib/ui/profile/usecases/initialize_profile_use_case.dart
@@ -1,5 +1,6 @@
 import 'package:hypha_wallet/core/error_handler/model/hypha_error.dart';
 import 'package:hypha_wallet/core/network/api/aws_amplify/amplify_service.dart';
+import 'package:hypha_wallet/core/network/api/services/remote_config_service.dart';
 import 'package:hypha_wallet/ui/architecture/result/result.dart';
 
 class InitializeProfileUseCase {
@@ -7,12 +8,17 @@ class InitializeProfileUseCase {
 
   InitializeProfileUseCase(this._amplifyService);
 
-  Future<Result<bool, HyphaError>> run({required String accountName, required String name}) async {
+  Future<Result<bool, HyphaError>> run(
+      {required String accountName, required String name, required Network network}) async {
     try {
       if (_amplifyService.isConnected()) {
-        final credentials = await _amplifyService.getCredentials();
+        final credentials = await _amplifyService.getCredentials(network);
         // ignore: unused_local_variable
-        final res = await _amplifyService.initializeProfile(name: name, s3Identity: credentials.userIdentityId!);
+        final res = await _amplifyService.initializeProfile(
+          name: name,
+          s3Identity: credentials.userIdentityId!,
+          network: network,
+        );
         return Result.value(true);
       } else {
         return Result.error(HyphaError.api('User must be logged in.'));

--- a/lib/ui/profile/usecases/ppp_sign_up_use_case.dart
+++ b/lib/ui/profile/usecases/ppp_sign_up_use_case.dart
@@ -1,5 +1,6 @@
 import 'package:hypha_wallet/core/error_handler/model/hypha_error.dart';
 import 'package:hypha_wallet/core/network/api/aws_amplify/amplify_service.dart';
+import 'package:hypha_wallet/core/network/api/services/remote_config_service.dart';
 import 'package:hypha_wallet/ui/architecture/result/result.dart';
 
 class PPPSignUpUseCase {
@@ -7,10 +8,10 @@ class PPPSignUpUseCase {
 
   PPPSignUpUseCase(this._amplifyService);
 
-  Future<Result<bool, HyphaError>> run(String accountName) async {
+  Future<Result<bool, HyphaError>> run(String accountName, Network network) async {
     try {
       // ignore: unused_local_variable
-      final res = await _amplifyService.signUp(accountName);
+      final res = await _amplifyService.signUp(accountName, network);
       return Result.value(true);
     } catch (error) {
       print('PPPSignUpUseCase error $error');

--- a/lib/ui/profile/usecases/profile_login_use_case.dart
+++ b/lib/ui/profile/usecases/profile_login_use_case.dart
@@ -1,5 +1,6 @@
 import 'package:hypha_wallet/core/error_handler/model/hypha_error.dart';
 import 'package:hypha_wallet/core/network/api/aws_amplify/amplify_service.dart';
+import 'package:hypha_wallet/core/network/api/services/remote_config_service.dart';
 import 'package:hypha_wallet/ui/architecture/result/result.dart';
 
 class ProfileLoginUseCase {
@@ -7,10 +8,10 @@ class ProfileLoginUseCase {
 
   ProfileLoginUseCase(this._amplifyService);
 
-  Future<Result<bool, HyphaError>> run(String accountName) async {
+  Future<Result<bool, HyphaError>> run(String accountName, Network network) async {
     try {
       // ignore: unused_local_variable
-      final res = await _amplifyService.profileServiceLoginUser(accountName);
+      final res = await _amplifyService.profileServiceLoginUser(accountName, network);
       return Result.value(true);
     } catch (error) {
       print('ProfileLoginUseCase error $error');

--- a/lib/ui/profile/usecases/remove_avatar_use_case.dart
+++ b/lib/ui/profile/usecases/remove_avatar_use_case.dart
@@ -1,5 +1,6 @@
 import 'package:hypha_wallet/core/error_handler/model/hypha_error.dart';
 import 'package:hypha_wallet/core/network/api/aws_amplify/amplify_service.dart';
+import 'package:hypha_wallet/core/network/api/services/remote_config_service.dart';
 import 'package:hypha_wallet/ui/architecture/result/result.dart';
 import 'package:hypha_wallet/ui/profile/usecases/profile_login_use_case.dart';
 
@@ -9,14 +10,14 @@ class RemoveAvatarUseCase {
 
   RemoveAvatarUseCase(this._amplifyService, this._profileLoginUseCase);
 
-  Future<Result<bool, HyphaError>> run(String accountName) async {
+  Future<Result<bool, HyphaError>> run(String accountName, Network network) async {
     try {
       print('remove avatar');
-      final Result<bool, HyphaError> loginResult = await _profileLoginUseCase.run(accountName);
+      final Result<bool, HyphaError> loginResult = await _profileLoginUseCase.run(accountName, network);
 
       if (loginResult.isValue) {
         // ignore: unused_local_variable
-        final res = await _amplifyService.removeAvatar();
+        final res = await _amplifyService.removeAvatar(network);
         return Result.value(true);
       } else {
         print('Remove avatar error: login Failed ');

--- a/lib/ui/profile/usecases/set_bio_use_case.dart
+++ b/lib/ui/profile/usecases/set_bio_use_case.dart
@@ -1,5 +1,6 @@
 import 'package:hypha_wallet/core/error_handler/model/hypha_error.dart';
 import 'package:hypha_wallet/core/network/api/aws_amplify/amplify_service.dart';
+import 'package:hypha_wallet/core/network/api/services/remote_config_service.dart';
 import 'package:hypha_wallet/ui/architecture/result/result.dart';
 import 'package:hypha_wallet/ui/profile/usecases/profile_login_use_case.dart';
 
@@ -12,11 +13,11 @@ class SetBioUseCase {
   Future<Result<bool, HyphaError>> run(SetBioUseCaseInput input) async {
     try {
       print('set bio to ${input.profileBio}');
-      final Result<bool, HyphaError> loginResult = await _profileLoginUseCase.run(input.accountName);
+      final Result<bool, HyphaError> loginResult = await _profileLoginUseCase.run(input.accountName, input.network);
 
       if (loginResult.isValue) {
         // ignore: unused_local_variable
-        final res = await _amplifyService.setBio(input.profileBio);
+        final res = await _amplifyService.setBio(input.profileBio, input.network);
         return Result.value(true);
       } else {
         print('SetBioUseCase error login Failed ');
@@ -33,6 +34,7 @@ class SetBioUseCase {
 class SetBioUseCaseInput {
   final String accountName;
   final String profileBio;
+  final Network network;
 
-  SetBioUseCaseInput({required this.accountName, required this.profileBio});
+  SetBioUseCaseInput({required this.accountName, required this.profileBio, required this.network});
 }

--- a/lib/ui/profile/usecases/set_image_use_case.dart
+++ b/lib/ui/profile/usecases/set_image_use_case.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:hypha_wallet/core/error_handler/model/hypha_error.dart';
 import 'package:hypha_wallet/core/network/api/aws_amplify/amplify_service.dart';
+import 'package:hypha_wallet/core/network/api/services/remote_config_service.dart';
 import 'package:hypha_wallet/ui/architecture/result/result.dart';
 import 'package:hypha_wallet/ui/profile/usecases/profile_login_use_case.dart';
 import 'package:image_picker/image_picker.dart';
@@ -15,19 +16,19 @@ class SetImageUseCase {
 
   SetImageUseCase(this._amplifyService, this._profileLoginUseCase);
 
-  Future<Result<bool, HyphaError>> run(XFile image, String accountName) async {
+  Future<Result<bool, HyphaError>> run(XFile image, String accountName, Network network) async {
     final File imageFile = File(image.path);
-    return runFile(imageFile, accountName);
+    return runFile(imageFile, accountName, network);
   }
 
-  Future<Result<bool, HyphaError>> runFileName(String filePath, String accountName) async {
+  Future<Result<bool, HyphaError>> runFileName(String filePath, String accountName, Network network) async {
     final File imageFile = File(filePath);
-    return runFile(imageFile, accountName);
+    return runFile(imageFile, accountName, network);
   }
 
-  Future<Result<bool, HyphaError>> runFile(File image, String accountName) async {
+  Future<Result<bool, HyphaError>> runFile(File image, String accountName, Network network) async {
     try {
-      final Result<bool, HyphaError> loginResult = await _profileLoginUseCase.run(accountName);
+      final Result<bool, HyphaError> loginResult = await _profileLoginUseCase.run(accountName, network);
 
       if (loginResult.isValue) {
         final File imageFile = File(image.path);
@@ -36,7 +37,7 @@ class SetImageUseCase {
         print('file size: ${imageFile.lengthSync()}');
         print('file name: $filename');
 
-        final res = await _amplifyService.setPicture(imageFile, filename);
+        final res = await _amplifyService.setPicture(imageFile, filename, network);
         return Result.value(true);
       } else {
         print('SetImageUseCase error login Failed ');

--- a/lib/ui/profile/usecases/set_name_use_case.dart
+++ b/lib/ui/profile/usecases/set_name_use_case.dart
@@ -1,5 +1,6 @@
 import 'package:hypha_wallet/core/error_handler/model/hypha_error.dart';
 import 'package:hypha_wallet/core/network/api/aws_amplify/amplify_service.dart';
+import 'package:hypha_wallet/core/network/api/services/remote_config_service.dart';
 import 'package:hypha_wallet/ui/architecture/result/result.dart';
 import 'package:hypha_wallet/ui/profile/usecases/profile_login_use_case.dart';
 
@@ -9,13 +10,14 @@ class SetNameUseCase {
 
   SetNameUseCase(this._amplifyService, this._profileLoginUseCase);
 
-  Future<Result<bool, HyphaError>> run({required String accountName, required String name}) async {
+  Future<Result<bool, HyphaError>> run(
+      {required String accountName, required String name, required Network network}) async {
     try {
       // ignore: unused_local_variable
-      final Result<bool, HyphaError> loginResult = await _profileLoginUseCase.run(accountName);
+      final Result<bool, HyphaError> loginResult = await _profileLoginUseCase.run(accountName, network);
 
       // ignore: unused_local_variable
-      final res = await _amplifyService.setName(name);
+      final res = await _amplifyService.setName(name, network);
       return Result.value(true);
     } catch (error) {
       print('SetNameUseCase error $error');

--- a/lib/ui/search_user/interactor/search_user_bloc.dart
+++ b/lib/ui/search_user/interactor/search_user_bloc.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:bloc/bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:hypha_wallet/core/error_handler/model/hypha_error.dart';
-import 'package:hypha_wallet/core/network/api/services/remote_config_service.dart';
 import 'package:hypha_wallet/core/network/models/user_profile_data.dart';
 import 'package:hypha_wallet/core/network/repository/auth_repository.dart';
 import 'package:hypha_wallet/ui/architecture/interactor/page_states.dart';

--- a/lib/ui/send/usecases/send_token_use_case.dart
+++ b/lib/ui/send/usecases/send_token_use_case.dart
@@ -1,6 +1,5 @@
 import 'package:hypha_wallet/core/error_handler/model/hypha_error.dart';
 import 'package:hypha_wallet/core/network/api/eos_service.dart';
-import 'package:hypha_wallet/core/network/api/services/remote_config_service.dart';
 import 'package:hypha_wallet/core/network/models/symbol_model.dart';
 import 'package:hypha_wallet/core/network/models/token_model.dart';
 import 'package:hypha_wallet/core/network/models/token_value.dart';
@@ -36,7 +35,7 @@ class SendTokenUseCase {
       network: user.userProfileData.network,
     );
 
-    if(result.isValue) {
+    if (result.isValue) {
       return HResult.Result.value(result.asValue!.value);
     } else {
       return HResult.Result.error(HyphaError.generic('Error sending tokens'));

--- a/lib/ui/settings/interactor/settings_bloc.dart
+++ b/lib/ui/settings/interactor/settings_bloc.dart
@@ -71,7 +71,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     emit(state.copyWith(pageState: PageState.loading));
     final user = _authRepository.authDataOrCrash;
     final accountName = user.userProfileData.accountName;
-    await _deleteAccountUseCase.run(accountName);
+    await _deleteAccountUseCase.run(accountName, user.userProfileData.network);
     emit(state.copyWith(pageState: PageState.success));
   }
 

--- a/lib/ui/settings/usecases/delete_account_use_case.dart
+++ b/lib/ui/settings/usecases/delete_account_use_case.dart
@@ -1,5 +1,6 @@
 import 'package:hypha_wallet/core/error_handler/model/hypha_error.dart';
 import 'package:hypha_wallet/core/network/api/aws_amplify/amplify_service.dart';
+import 'package:hypha_wallet/core/network/api/services/remote_config_service.dart';
 import 'package:hypha_wallet/core/network/repository/auth_repository.dart';
 import 'package:hypha_wallet/ui/architecture/result/result.dart';
 
@@ -9,13 +10,13 @@ class DeleteAccountUseCase {
 
   DeleteAccountUseCase(this._amplifyService, this._authRepository);
 
-  Future<Result<bool, HyphaError>> run(String accountName) async {
+  Future<Result<bool, HyphaError>> run(String accountName, Network network) async {
     print('Delete Account: $accountName');
 
     try {
       /// 1 - Delete profile service account
-      await _amplifyService.profileServiceLoginUser(accountName);
-      final res = await _amplifyService.deleteAccount();
+      await _amplifyService.profileServiceLoginUser(accountName, network);
+      final res = await _amplifyService.deleteAccount(network);
 
       if (res) {
         /// 2 - logout and delete local data

--- a/test/profile_upload_repository_test.dart
+++ b/test/profile_upload_repository_test.dart
@@ -50,7 +50,7 @@ mixin MockUseCase {
 class MockSignupUseCase extends PPPSignUpUseCase with MockUseCase {
   MockSignupUseCase(super.amplifyService);
   @override
-  Future<Result<bool, HyphaError>> run(String accountName) async {
+  Future<Result<bool, HyphaError>> run(String accountName, Network network) async {
     return genericRun();
   }
 }
@@ -58,7 +58,7 @@ class MockSignupUseCase extends PPPSignUpUseCase with MockUseCase {
 class MockProfileLoginUseCase extends ProfileLoginUseCase with MockUseCase {
   MockProfileLoginUseCase(super.amplifyService);
   @override
-  Future<Result<bool, HyphaError>> run(String accountName) async {
+  Future<Result<bool, HyphaError>> run(String accountName, Network network) async {
     return genericRun();
   }
 }
@@ -66,7 +66,8 @@ class MockProfileLoginUseCase extends ProfileLoginUseCase with MockUseCase {
 class MockInitializeProfileUseCase extends InitializeProfileUseCase with MockUseCase {
   MockInitializeProfileUseCase(super.amplifyService);
   @override
-  Future<Result<bool, HyphaError>> run({required String accountName, required String name}) async {
+  Future<Result<bool, HyphaError>> run(
+      {required String accountName, required String name, required Network network}) async {
     return genericRun();
   }
 }
@@ -74,17 +75,17 @@ class MockInitializeProfileUseCase extends InitializeProfileUseCase with MockUse
 class MockSetImageUseCase extends SetImageUseCase with MockUseCase {
   MockSetImageUseCase(super.amplifyService, super._profileLoginUseCase);
   @override
-  Future<Result<bool, HyphaError>> runFileName(String filePath, String accountName) async {
+  Future<Result<bool, HyphaError>> runFileName(String filePath, String accountName, Network network) async {
     return genericRun();
   }
 
   @override
-  Future<Result<bool, HyphaError>> run(XFile image, String accountName) async {
+  Future<Result<bool, HyphaError>> run(XFile image, String accountName, Network network) async {
     return genericRun();
   }
 
   @override
-  Future<Result<bool, HyphaError>> runFile(File imageFile, String accountName) async {
+  Future<Result<bool, HyphaError>> runFile(File imageFile, String accountName, Network network) async {
     return genericRun();
   }
 }
@@ -137,6 +138,7 @@ void main() {
   test('Test upload and restart', () async {
     await service.scheduleUpload(
       accountName: accountName,
+      network: Network.telos,
       userName: name,
       fileName: fileName,
     );
@@ -156,6 +158,7 @@ void main() {
       accountName: accountName,
       userName: name,
       fileName: fileName,
+      network: Network.telos,
     );
     await service.start();
     final data2 = await prefs.getSignupData();
@@ -172,6 +175,7 @@ void main() {
       accountName: accountName,
       userName: name,
       fileName: fileName,
+      network: Network.telos,
     );
     allUseCases[1].isFailing = true;
     expect(allUseCases[2].wasCalled, false, reason: '2 was not called 1');
@@ -210,6 +214,7 @@ void main() {
       accountName: accountName,
       userName: name,
       fileName: fileName,
+      network: Network.telos,
     );
     allUseCases[2].isFailing = true;
     allUseCases[2].onCall = (useCase, counter) {


### PR DESCRIPTION
For your review

Seems like we could do something more elegant than using "network" everywhere

For example we could pass it around instead of accountName

The problem is now that network is stored in user profile, and I am not sure we always have one

If we always have one then we could always pass around a user profile, or an object with _only_ accountName and network everywhere, and not have this parameter pollute the whole code base. 

IDK