### PR TITLE
Retry call when failed

### DIFF
--- a/lib/core/network/api/aws_amplify/aws_authenticated_request.dart
+++ b/lib/core/network/api/aws_amplify/aws_authenticated_request.dart
@@ -56,8 +56,8 @@ Future<dynamic> awsAuthenticatedRequest({
     return response.data;
   } catch (error) {
     print('Call failed $path $error');
-    if (error is DioError) {
-      final DioError dioError = error;
+    if (error is DioException) {
+      final DioException dioError = error;
       print('message: ${dioError.message}');
       print('status code: ${dioError.response?.statusCode}');
       print('message: ${dioError.response?.statusMessage}');

--- a/lib/core/network/api/services/dao_service.dart
+++ b/lib/core/network/api/services/dao_service.dart
@@ -28,7 +28,7 @@ class DaoService {
     } catch (error) {
       print('Error accessing graphQL');
       print(error);
-      if (error is DioError) {
+      if (error is DioException) {
         final dioError = error;
         print('message: ${dioError.message}');
         print('status code: ${dioError.response?.statusCode}');

--- a/lib/core/network/api/services/user_account_service.dart
+++ b/lib/core/network/api/services/user_account_service.dart
@@ -35,7 +35,7 @@ class UserAccountService {
     } catch (error) {
       print('Error creating account');
       print(error);
-      if (error is DioError) {
+      if (error is DioException) {
         final dioError = error;
         print('message: ${dioError.message}');
         print('status code: ${dioError.response?.statusCode}');

--- a/lib/core/network/dio_exception.dart
+++ b/lib/core/network/dio_exception.dart
@@ -3,34 +3,31 @@ import 'package:dio/dio.dart';
 class DioExceptions implements Exception {
   late String message;
 
-  DioExceptions.fromDioError(DioError dioError) {
+  DioExceptions.fromDioError(DioException dioError) {
     switch (dioError.type) {
-      case DioErrorType.cancel:
+      case DioException.requestCancelled:
         message = 'Request to API server was cancelled';
         break;
-      case DioErrorType.connectionTimeout:
+      case DioException.connectionTimeout:
         message = 'Connection timeout with API server';
         break;
-      case DioErrorType.receiveTimeout:
+      case DioException.receiveTimeout:
         message = 'Receive timeout in connection with API server';
         break;
-      case DioErrorType.badResponse:
+      case DioException.badResponse:
         message = _handleError(
           dioError.response?.statusCode,
           dioError.response?.data,
         );
         break;
-      case DioErrorType.sendTimeout:
+      case DioException.sendTimeout:
         message = 'Send timeout in connection with API server';
         break;
-      case DioErrorType.unknown:
+      default:
         if (dioError.message?.contains('SocketException') == true) {
           message = 'No Internet';
           break;
         }
-        message = 'Unexpected error occurred';
-        break;
-      default:
         message = 'Something went wrong';
         break;
     }

--- a/lib/core/network/repository/transaction_history_repository.dart
+++ b/lib/core/network/repository/transaction_history_repository.dart
@@ -18,7 +18,7 @@ class TransactionHistoryRepository {
           : await service.getAllTransactions(userAccount);
       final List<dynamic> transfers = response.data['actions'].toList();
       return Result.value(transfers.map((transfer) => TransactionModel.fromJson(transfer)).toList());
-    } on DioError catch (e) {
+    } on DioException catch (e) {
       final errorMessage = DioExceptions.fromDioError(e).toString();
       return Result.error(HyphaError.api(errorMessage));
     } catch (e) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -293,10 +293,18 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: "347d56c26d63519552ef9a569f2a593dda99a81fdbdff13c584b7197cfe05059"
+      sha256: "3866d67f93523161b643187af65f5ac08bc991a5bcdaf41a2d587fe4ccb49993"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.2"
+    version: "5.3.0"
+  dio_smart_retry:
+    dependency: "direct main"
+    description:
+      name: dio_smart_retry
+      sha256: "1a2d0cf73ab56bf5998b375cda2d51f45c77268e712e4073f232cdc7753a94b2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
   disposebag:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -88,8 +88,9 @@ dependencies:
   image_picker: ^0.8.6
 
   # Network
-  dio: ^5.1.2
-
+  dio: ^5.3.0
+  # Retry failed calls
+  dio_smart_retry: ^5.0.0
   # API Logs in Terminal
   pretty_dio_logger: ^1.3.1
 


### PR DESCRIPTION
Default retryable status codes list 
Responses with this http status codes will be retried by default:

408: RequestTimeout
429: TooManyRequests
500: InternalServerError
502: BadGateway
503: ServiceUnavailable
504: GatewayTimeout
440: LoginTimeout (IIS)
460: ClientClosedRequest (AWS Elastic Load Balancer)
499: ClientClosedRequest (ngnix)
520: WebServerReturnedUnknownError
521: WebServerIsDown
522: ConnectionTimedOut
523: OriginIsUnreachable
524: TimeoutOccurred
525: SSLHandshakeFailed
527: RailgunError
598: NetworkReadTimeoutError
599: NetworkConnectTimeoutError


They will be retried Once, after a one second wait. 