### PR TITLE
Bugfix/fix onboarding

### DIFF
--- a/lib/core/di/bloc_module.dart
+++ b/lib/core/di/bloc_module.dart
@@ -73,14 +73,14 @@ void _registerBlocsModule() {
     ),
   );
 
-  _registerFactoryWithParams<CreateAccountBloc, XFile?, UserProfileData>(
-    (image, userProfileData) => CreateAccountBloc(
+  _registerFactoryWithParams<CreateAccountBloc, XFile?, String>(
+    (image, userName) => CreateAccountBloc(
       _getIt<CryptoAuthService>(),
       _getIt<CreateAccountUseCase>(),
       _getIt<FindAvailableAccountUseCase>(),
       _getIt<ErrorHandlerManager>(),
       image,
-      userProfileData,
+      userName,
     ),
   );
 

--- a/lib/core/network/repository/auth_repository.dart
+++ b/lib/core/network/repository/auth_repository.dart
@@ -11,7 +11,6 @@ import 'package:hypha_wallet/core/logging/log_helper.dart';
 import 'package:hypha_wallet/core/network/api/aws_amplify/amplify_service.dart';
 import 'package:hypha_wallet/core/network/api/aws_amplify/profile_upload_repository.dart';
 import 'package:hypha_wallet/core/network/api/services/user_account_service.dart';
-import 'package:hypha_wallet/core/network/models/network.dart';
 import 'package:hypha_wallet/core/network/models/user_profile_data.dart';
 import 'package:hypha_wallet/core/shared_preferences/hypha_shared_prefs.dart';
 import 'package:hypha_wallet/ui/blocs/deeplink/deeplink_bloc.dart';
@@ -62,18 +61,16 @@ class AuthRepository {
 
       final response = await _userService.createUserAccount(
         code: inviteLinkData.code,
-        network: inviteLinkData.chain,
+        network: inviteLinkData.network.name,
         accountName: accountName,
         publicKey: userAuthData.publicKey.toString(),
       );
-
-      final network = Network.fromString(inviteLinkData.chain);
 
       _saveUserData(
         UserProfileData(
           accountName: accountName,
           userName: userName,
-          network: network,
+          network: inviteLinkData.network,
         ),
         userAuthData,
         false,
@@ -82,7 +79,7 @@ class AuthRepository {
       print('create ppp account for $accountName with image ${image?.path}');
       await _uploadRepository.scheduleUpload(
         accountName: accountName,
-        network: network,
+        network: inviteLinkData.network,
         userName: userName,
         fileName: image?.path,
       );

--- a/lib/ui/blocs/deeplink/deeplink_bloc.dart
+++ b/lib/ui/blocs/deeplink/deeplink_bloc.dart
@@ -7,6 +7,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:hypha_wallet/core/crypto/dart_esr/dart_esr.dart';
 import 'package:hypha_wallet/core/crypto/seeds_esr/scan_qr_code_result_data.dart';
 import 'package:hypha_wallet/core/logging/log_helper.dart';
+import 'package:hypha_wallet/core/network/models/network.dart';
 import 'package:hypha_wallet/ui/home_page/usecases/parse_qr_code_use_case.dart';
 
 part 'deeplink_bloc.freezed.dart';
@@ -89,7 +90,7 @@ class DeeplinkBloc extends Bloc<DeeplinkEvent, DeeplinkState> {
       /// Emit new state with data from link
       emit(
         state.copyWith(
-          inviteLinkData: InviteLinkData(code: code, chain: chain, dao: dao),
+          inviteLinkData: InviteLinkData(code: code, network: Network.fromString(chain), dao: dao),
           command: const PageCommand.navigateToCreateAccount(),
         ),
       );

--- a/lib/ui/blocs/deeplink/deeplink_state.dart
+++ b/lib/ui/blocs/deeplink/deeplink_state.dart
@@ -10,8 +10,8 @@ class DeeplinkState with _$DeeplinkState {
 
 class InviteLinkData {
   final String code;
-  final String chain;
+  final Network network;
   final String? dao;
 
-  InviteLinkData({required this.code, required this.chain, this.dao});
+  InviteLinkData({required this.code, required this.network, this.dao});
 }

--- a/lib/ui/onboarding/create_account/components/create_account_view.dart
+++ b/lib/ui/onboarding/create_account/components/create_account_view.dart
@@ -91,7 +91,6 @@ class CreateAccountView extends StatelessWidget {
       () => EditAccountPage(PageParams(
         file: state.image,
         name: state.userName,
-        network: state.network,
       )),
       transition: Get.Transition.rightToLeft,
     );

--- a/lib/ui/onboarding/create_account/create_account_page.dart
+++ b/lib/ui/onboarding/create_account/create_account_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get/get.dart' as Get;
 import 'package:get_it/get_it.dart';
-import 'package:hypha_wallet/core/network/models/network.dart';
 import 'package:hypha_wallet/design/progress_indicator/hypha_full_page_progress_indicator.dart';
 import 'package:hypha_wallet/ui/blocs/deeplink/deeplink_bloc.dart';
 import 'package:hypha_wallet/ui/onboarding/create_account/components/create_account_view.dart';
@@ -22,9 +21,7 @@ class CreateAccountPage extends StatelessWidget {
       create: (context) => GetIt.I.get<CreateAccountBloc>(param1: _file, param2: _name)
         ..add(
           CreateAccountEvent.initial(
-            Network.fromString(
-              context.read<DeeplinkBloc>().state.inviteLinkData!.chain,
-            ),
+            context.read<DeeplinkBloc>().state.inviteLinkData!.network,
           ),
         ),
       child: BlocListener<CreateAccountBloc, CreateAccountState>(

--- a/lib/ui/onboarding/create_account/create_account_page.dart
+++ b/lib/ui/onboarding/create_account/create_account_page.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get/get.dart' as Get;
 import 'package:get_it/get_it.dart';
+import 'package:hypha_wallet/core/network/models/network.dart';
 import 'package:hypha_wallet/design/progress_indicator/hypha_full_page_progress_indicator.dart';
+import 'package:hypha_wallet/ui/blocs/deeplink/deeplink_bloc.dart';
 import 'package:hypha_wallet/ui/onboarding/create_account/components/create_account_view.dart';
 import 'package:hypha_wallet/ui/onboarding/create_account/interactor/create_account_bloc.dart';
 import 'package:hypha_wallet/ui/onboarding/create_account_success_page.dart';
@@ -17,8 +19,14 @@ class CreateAccountPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (context) =>
-          GetIt.I.get<CreateAccountBloc>(param1: _file, param2: _name)..add(const CreateAccountEvent.initial()),
+      create: (context) => GetIt.I.get<CreateAccountBloc>(param1: _file, param2: _name)
+        ..add(
+          CreateAccountEvent.initial(
+            Network.fromString(
+              context.read<DeeplinkBloc>().state.inviteLinkData!.chain,
+            ),
+          ),
+        ),
       child: BlocListener<CreateAccountBloc, CreateAccountState>(
         listenWhen: (previous, current) => previous.command != current.command,
         listener: (context, state) {

--- a/lib/ui/onboarding/create_account/interactor/create_account_bloc.dart
+++ b/lib/ui/onboarding/create_account/interactor/create_account_bloc.dart
@@ -7,7 +7,6 @@ import 'package:hypha_wallet/core/error_handler/model/hypha_error.dart';
 import 'package:hypha_wallet/core/local/models/user_auth_data.dart';
 import 'package:hypha_wallet/core/local/services/crypto_auth_service.dart';
 import 'package:hypha_wallet/core/network/models/network.dart';
-import 'package:hypha_wallet/core/network/models/user_profile_data.dart';
 import 'package:hypha_wallet/ui/architecture/interactor/page_states.dart';
 import 'package:hypha_wallet/ui/architecture/result/result.dart' as Hypha;
 import 'package:hypha_wallet/ui/blocs/deeplink/deeplink_bloc.dart';
@@ -33,8 +32,8 @@ class CreateAccountBloc extends Bloc<CreateAccountEvent, CreateAccountState> {
     this._findAvailableAccountUseCase,
     this._errorHandlerManager,
     XFile? image,
-    UserProfileData user,
-  ) : super(CreateAccountState(userName: user.accountName, network: user.network, image: image)) {
+    String userName,
+  ) : super(CreateAccountState(userName: userName, image: image)) {
     on<_Initial>(_initial);
     on<_OnNextTapped>(_onNextTapped);
     on<_ClearPageCommand>((_, emit) => emit(state.copyWith(command: null)));
@@ -43,7 +42,7 @@ class CreateAccountBloc extends Bloc<CreateAccountEvent, CreateAccountState> {
   Future<void> _initial(_Initial event, Emitter<CreateAccountState> emit) async {
     emit(state.copyWith(pageState: PageState.success, command: const PageCommand.showLoadingDialog()));
     final Hypha.Result<String, HyphaError> result =
-        await _findAvailableAccountUseCase.run(CheckAccountInput(state.userName, state.network));
+        await _findAvailableAccountUseCase.run(CheckAccountInput(state.userName, event.network));
     if (result.isValue) {
       emit(state.copyWith(
         pageState: PageState.success,

--- a/lib/ui/onboarding/create_account/interactor/create_account_bloc.freezed.dart
+++ b/lib/ui/onboarding/create_account/interactor/create_account_bloc.freezed.dart
@@ -18,21 +18,21 @@ final _privateConstructorUsedError = UnsupportedError(
 mixin _$CreateAccountEvent {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function() initial,
+    required TResult Function(Network network) initial,
     required TResult Function() clearPageCommand,
     required TResult Function(InviteLinkData inviteLinkData) onNextTapped,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function()? initial,
+    TResult? Function(Network network)? initial,
     TResult? Function()? clearPageCommand,
     TResult? Function(InviteLinkData inviteLinkData)? onNextTapped,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function()? initial,
+    TResult Function(Network network)? initial,
     TResult Function()? clearPageCommand,
     TResult Function(InviteLinkData inviteLinkData)? onNextTapped,
     required TResult orElse(),
@@ -85,6 +85,8 @@ abstract class _$$_InitialCopyWith<$Res> {
   factory _$$_InitialCopyWith(
           _$_Initial value, $Res Function(_$_Initial) then) =
       __$$_InitialCopyWithImpl<$Res>;
+  @useResult
+  $Res call({Network network});
 }
 
 /// @nodoc
@@ -93,57 +95,81 @@ class __$$_InitialCopyWithImpl<$Res>
     implements _$$_InitialCopyWith<$Res> {
   __$$_InitialCopyWithImpl(_$_Initial _value, $Res Function(_$_Initial) _then)
       : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? network = null,
+  }) {
+    return _then(_$_Initial(
+      null == network
+          ? _value.network
+          : network // ignore: cast_nullable_to_non_nullable
+              as Network,
+    ));
+  }
 }
 
 /// @nodoc
 
 class _$_Initial implements _Initial {
-  const _$_Initial();
+  const _$_Initial(this.network);
+
+  @override
+  final Network network;
 
   @override
   String toString() {
-    return 'CreateAccountEvent.initial()';
+    return 'CreateAccountEvent.initial(network: $network)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$_Initial);
+        (other.runtimeType == runtimeType &&
+            other is _$_Initial &&
+            (identical(other.network, network) || other.network == network));
   }
 
   @override
-  int get hashCode => runtimeType.hashCode;
+  int get hashCode => Object.hash(runtimeType, network);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_InitialCopyWith<_$_Initial> get copyWith =>
+      __$$_InitialCopyWithImpl<_$_Initial>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function() initial,
+    required TResult Function(Network network) initial,
     required TResult Function() clearPageCommand,
     required TResult Function(InviteLinkData inviteLinkData) onNextTapped,
   }) {
-    return initial();
+    return initial(network);
   }
 
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function()? initial,
+    TResult? Function(Network network)? initial,
     TResult? Function()? clearPageCommand,
     TResult? Function(InviteLinkData inviteLinkData)? onNextTapped,
   }) {
-    return initial?.call();
+    return initial?.call(network);
   }
 
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function()? initial,
+    TResult Function(Network network)? initial,
     TResult Function()? clearPageCommand,
     TResult Function(InviteLinkData inviteLinkData)? onNextTapped,
     required TResult orElse(),
   }) {
     if (initial != null) {
-      return initial();
+      return initial(network);
     }
     return orElse();
   }
@@ -184,7 +210,12 @@ class _$_Initial implements _Initial {
 }
 
 abstract class _Initial implements CreateAccountEvent {
-  const factory _Initial() = _$_Initial;
+  const factory _Initial(final Network network) = _$_Initial;
+
+  Network get network;
+  @JsonKey(ignore: true)
+  _$$_InitialCopyWith<_$_Initial> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -225,7 +256,7 @@ class _$_ClearPageCommand implements _ClearPageCommand {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function() initial,
+    required TResult Function(Network network) initial,
     required TResult Function() clearPageCommand,
     required TResult Function(InviteLinkData inviteLinkData) onNextTapped,
   }) {
@@ -235,7 +266,7 @@ class _$_ClearPageCommand implements _ClearPageCommand {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function()? initial,
+    TResult? Function(Network network)? initial,
     TResult? Function()? clearPageCommand,
     TResult? Function(InviteLinkData inviteLinkData)? onNextTapped,
   }) {
@@ -245,7 +276,7 @@ class _$_ClearPageCommand implements _ClearPageCommand {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function()? initial,
+    TResult Function(Network network)? initial,
     TResult Function()? clearPageCommand,
     TResult Function(InviteLinkData inviteLinkData)? onNextTapped,
     required TResult orElse(),
@@ -360,7 +391,7 @@ class _$_OnNextTapped implements _OnNextTapped {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function() initial,
+    required TResult Function(Network network) initial,
     required TResult Function() clearPageCommand,
     required TResult Function(InviteLinkData inviteLinkData) onNextTapped,
   }) {
@@ -370,7 +401,7 @@ class _$_OnNextTapped implements _OnNextTapped {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function()? initial,
+    TResult? Function(Network network)? initial,
     TResult? Function()? clearPageCommand,
     TResult? Function(InviteLinkData inviteLinkData)? onNextTapped,
   }) {
@@ -380,7 +411,7 @@ class _$_OnNextTapped implements _OnNextTapped {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function()? initial,
+    TResult Function(Network network)? initial,
     TResult Function()? clearPageCommand,
     TResult Function(InviteLinkData inviteLinkData)? onNextTapped,
     required TResult orElse(),
@@ -441,7 +472,6 @@ mixin _$CreateAccountState {
   PageState get pageState => throw _privateConstructorUsedError;
   XFile? get image => throw _privateConstructorUsedError;
   String get userName => throw _privateConstructorUsedError;
-  Network get network => throw _privateConstructorUsedError;
   String? get userAccount => throw _privateConstructorUsedError;
   PageCommand? get command => throw _privateConstructorUsedError;
 
@@ -460,7 +490,6 @@ abstract class $CreateAccountStateCopyWith<$Res> {
       {PageState pageState,
       XFile? image,
       String userName,
-      Network network,
       String? userAccount,
       PageCommand? command});
 
@@ -483,7 +512,6 @@ class _$CreateAccountStateCopyWithImpl<$Res, $Val extends CreateAccountState>
     Object? pageState = null,
     Object? image = freezed,
     Object? userName = null,
-    Object? network = null,
     Object? userAccount = freezed,
     Object? command = freezed,
   }) {
@@ -500,10 +528,6 @@ class _$CreateAccountStateCopyWithImpl<$Res, $Val extends CreateAccountState>
           ? _value.userName
           : userName // ignore: cast_nullable_to_non_nullable
               as String,
-      network: null == network
-          ? _value.network
-          : network // ignore: cast_nullable_to_non_nullable
-              as Network,
       userAccount: freezed == userAccount
           ? _value.userAccount
           : userAccount // ignore: cast_nullable_to_non_nullable
@@ -540,7 +564,6 @@ abstract class _$$_CreateAccountStateCopyWith<$Res>
       {PageState pageState,
       XFile? image,
       String userName,
-      Network network,
       String? userAccount,
       PageCommand? command});
 
@@ -562,7 +585,6 @@ class __$$_CreateAccountStateCopyWithImpl<$Res>
     Object? pageState = null,
     Object? image = freezed,
     Object? userName = null,
-    Object? network = null,
     Object? userAccount = freezed,
     Object? command = freezed,
   }) {
@@ -579,10 +601,6 @@ class __$$_CreateAccountStateCopyWithImpl<$Res>
           ? _value.userName
           : userName // ignore: cast_nullable_to_non_nullable
               as String,
-      network: null == network
-          ? _value.network
-          : network // ignore: cast_nullable_to_non_nullable
-              as Network,
       userAccount: freezed == userAccount
           ? _value.userAccount
           : userAccount // ignore: cast_nullable_to_non_nullable
@@ -602,7 +620,6 @@ class _$_CreateAccountState implements _CreateAccountState {
       {this.pageState = PageState.initial,
       this.image,
       required this.userName,
-      required this.network,
       this.userAccount,
       this.command});
 
@@ -614,15 +631,13 @@ class _$_CreateAccountState implements _CreateAccountState {
   @override
   final String userName;
   @override
-  final Network network;
-  @override
   final String? userAccount;
   @override
   final PageCommand? command;
 
   @override
   String toString() {
-    return 'CreateAccountState(pageState: $pageState, image: $image, userName: $userName, network: $network, userAccount: $userAccount, command: $command)';
+    return 'CreateAccountState(pageState: $pageState, image: $image, userName: $userName, userAccount: $userAccount, command: $command)';
   }
 
   @override
@@ -635,7 +650,6 @@ class _$_CreateAccountState implements _CreateAccountState {
             (identical(other.image, image) || other.image == image) &&
             (identical(other.userName, userName) ||
                 other.userName == userName) &&
-            (identical(other.network, network) || other.network == network) &&
             (identical(other.userAccount, userAccount) ||
                 other.userAccount == userAccount) &&
             (identical(other.command, command) || other.command == command));
@@ -643,7 +657,7 @@ class _$_CreateAccountState implements _CreateAccountState {
 
   @override
   int get hashCode => Object.hash(
-      runtimeType, pageState, image, userName, network, userAccount, command);
+      runtimeType, pageState, image, userName, userAccount, command);
 
   @JsonKey(ignore: true)
   @override
@@ -658,7 +672,6 @@ abstract class _CreateAccountState implements CreateAccountState {
       {final PageState pageState,
       final XFile? image,
       required final String userName,
-      required final Network network,
       final String? userAccount,
       final PageCommand? command}) = _$_CreateAccountState;
 
@@ -668,8 +681,6 @@ abstract class _CreateAccountState implements CreateAccountState {
   XFile? get image;
   @override
   String get userName;
-  @override
-  Network get network;
   @override
   String? get userAccount;
   @override

--- a/lib/ui/onboarding/create_account/interactor/create_account_event.dart
+++ b/lib/ui/onboarding/create_account/interactor/create_account_event.dart
@@ -2,7 +2,7 @@ part of 'create_account_bloc.dart';
 
 @freezed
 class CreateAccountEvent with _$CreateAccountEvent {
-  const factory CreateAccountEvent.initial() = _Initial;
+  const factory CreateAccountEvent.initial(Network network) = _Initial;
   const factory CreateAccountEvent.clearPageCommand() = _ClearPageCommand;
   const factory CreateAccountEvent.onNextTapped(InviteLinkData inviteLinkData) = _OnNextTapped;
 }

--- a/lib/ui/onboarding/create_account/interactor/create_account_state.dart
+++ b/lib/ui/onboarding/create_account/interactor/create_account_state.dart
@@ -6,7 +6,6 @@ class CreateAccountState with _$CreateAccountState {
     @Default(PageState.initial) PageState pageState,
     XFile? image,
     required String userName,
-    required Network network,
     String? userAccount,
     PageCommand? command,
   }) = _CreateAccountState;

--- a/lib/ui/onboarding/edit_account/components/edit_account_view.dart
+++ b/lib/ui/onboarding/edit_account/components/edit_account_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get/get.dart' as Get;
 import 'package:hypha_wallet/core/extension/scope_functions.dart';
+import 'package:hypha_wallet/core/network/models/network.dart';
 import 'package:hypha_wallet/design/avatar_image/hypha_avatar_image.dart';
 import 'package:hypha_wallet/design/background/hypha_page_background.dart';
 import 'package:hypha_wallet/design/bottom_component/hypha_safe_bottom_navigation_bar.dart';
@@ -32,6 +33,12 @@ class _EditAccountViewState extends State<EditAccountView> {
     super.dispose();
   }
 
+  Network _getNetwork(BuildContext context) {
+    final inviteLinkData = context.read<DeeplinkBloc>().state.inviteLinkData!;
+    final network = Network.fromString(inviteLinkData.chain);
+    return network;
+  }
+
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<EditAccountBloc, EditAccountState>(
@@ -39,7 +46,7 @@ class _EditAccountViewState extends State<EditAccountView> {
         void _onSearchChanged(String value) {
           if (_debounce?.isActive ?? false) _debounce?.cancel();
           _debounce = Timer(const Duration(milliseconds: 500), () {
-            context.read<EditAccountBloc>().add(EditAccountEvent.onAccountChange(value, state.network));
+            context.read<EditAccountBloc>().add(EditAccountEvent.onAccountChange(value, _getNetwork(context)));
           });
         }
 

--- a/lib/ui/onboarding/edit_account/components/edit_account_view.dart
+++ b/lib/ui/onboarding/edit_account/components/edit_account_view.dart
@@ -34,9 +34,7 @@ class _EditAccountViewState extends State<EditAccountView> {
   }
 
   Network _getNetwork(BuildContext context) {
-    final inviteLinkData = context.read<DeeplinkBloc>().state.inviteLinkData!;
-    final network = Network.fromString(inviteLinkData.chain);
-    return network;
+    return context.read<DeeplinkBloc>().state.inviteLinkData!.network;
   }
 
   @override

--- a/lib/ui/onboarding/edit_account/edit_account_page.dart
+++ b/lib/ui/onboarding/edit_account/edit_account_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get/get.dart' as Get;
 import 'package:get_it/get_it.dart';
-import 'package:hypha_wallet/core/network/models/network.dart';
 import 'package:hypha_wallet/design/progress_indicator/hypha_full_page_progress_indicator.dart';
 import 'package:hypha_wallet/ui/onboarding/create_account_success_page.dart';
 import 'package:hypha_wallet/ui/onboarding/edit_account/components/edit_account_view.dart';
@@ -51,7 +50,6 @@ class EditAccountPage extends StatelessWidget {
 class PageParams {
   final XFile? file;
   final String name;
-  final Network network;
 
-  const PageParams({this.file, required this.name, required this.network});
+  const PageParams({this.file, required this.name});
 }

--- a/lib/ui/onboarding/edit_account/interactor/edit_account_bloc.dart
+++ b/lib/ui/onboarding/edit_account/interactor/edit_account_bloc.dart
@@ -39,7 +39,7 @@ class EditAccountBloc extends Bloc<EditAccountEvent, EditAccountState> {
     this._errorHandlerManager,
     this._cryptoAuthService,
     PageParams pageParams,
-  ) : super(EditAccountState(userName: pageParams.name, image: pageParams.file, network: pageParams.network)) {
+  ) : super(EditAccountState(userName: pageParams.name, image: pageParams.file)) {
     on<_Initial>(_initial);
     on<_OnNextPressed>(_onNextPressed);
     on<_ClearPageCommand>((_, emit) => emit(state.copyWith(command: null)));

--- a/lib/ui/onboarding/edit_account/interactor/edit_account_bloc.freezed.dart
+++ b/lib/ui/onboarding/edit_account/interactor/edit_account_bloc.freezed.dart
@@ -620,7 +620,6 @@ mixin _$EditAccountState {
   PageState get pageState => throw _privateConstructorUsedError;
   XFile? get image => throw _privateConstructorUsedError;
   String get userName => throw _privateConstructorUsedError;
-  Network get network => throw _privateConstructorUsedError;
   String? get userAccount => throw _privateConstructorUsedError;
   PageCommand? get command => throw _privateConstructorUsedError;
   List<UserAccountRequirement> get userAccountRequirements =>
@@ -641,7 +640,6 @@ abstract class $EditAccountStateCopyWith<$Res> {
       {PageState pageState,
       XFile? image,
       String userName,
-      Network network,
       String? userAccount,
       PageCommand? command,
       List<UserAccountRequirement> userAccountRequirements});
@@ -665,7 +663,6 @@ class _$EditAccountStateCopyWithImpl<$Res, $Val extends EditAccountState>
     Object? pageState = null,
     Object? image = freezed,
     Object? userName = null,
-    Object? network = null,
     Object? userAccount = freezed,
     Object? command = freezed,
     Object? userAccountRequirements = null,
@@ -683,10 +680,6 @@ class _$EditAccountStateCopyWithImpl<$Res, $Val extends EditAccountState>
           ? _value.userName
           : userName // ignore: cast_nullable_to_non_nullable
               as String,
-      network: null == network
-          ? _value.network
-          : network // ignore: cast_nullable_to_non_nullable
-              as Network,
       userAccount: freezed == userAccount
           ? _value.userAccount
           : userAccount // ignore: cast_nullable_to_non_nullable
@@ -727,7 +720,6 @@ abstract class _$$_CreateAccountStateCopyWith<$Res>
       {PageState pageState,
       XFile? image,
       String userName,
-      Network network,
       String? userAccount,
       PageCommand? command,
       List<UserAccountRequirement> userAccountRequirements});
@@ -750,7 +742,6 @@ class __$$_CreateAccountStateCopyWithImpl<$Res>
     Object? pageState = null,
     Object? image = freezed,
     Object? userName = null,
-    Object? network = null,
     Object? userAccount = freezed,
     Object? command = freezed,
     Object? userAccountRequirements = null,
@@ -768,10 +759,6 @@ class __$$_CreateAccountStateCopyWithImpl<$Res>
           ? _value.userName
           : userName // ignore: cast_nullable_to_non_nullable
               as String,
-      network: null == network
-          ? _value.network
-          : network // ignore: cast_nullable_to_non_nullable
-              as Network,
       userAccount: freezed == userAccount
           ? _value.userAccount
           : userAccount // ignore: cast_nullable_to_non_nullable
@@ -795,7 +782,6 @@ class _$_CreateAccountState extends _CreateAccountState {
       {this.pageState = PageState.initial,
       this.image,
       required this.userName,
-      required this.network,
       this.userAccount,
       this.command,
       final List<UserAccountRequirement> userAccountRequirements = const []})
@@ -809,8 +795,6 @@ class _$_CreateAccountState extends _CreateAccountState {
   final XFile? image;
   @override
   final String userName;
-  @override
-  final Network network;
   @override
   final String? userAccount;
   @override
@@ -827,7 +811,7 @@ class _$_CreateAccountState extends _CreateAccountState {
 
   @override
   String toString() {
-    return 'EditAccountState(pageState: $pageState, image: $image, userName: $userName, network: $network, userAccount: $userAccount, command: $command, userAccountRequirements: $userAccountRequirements)';
+    return 'EditAccountState(pageState: $pageState, image: $image, userName: $userName, userAccount: $userAccount, command: $command, userAccountRequirements: $userAccountRequirements)';
   }
 
   @override
@@ -840,7 +824,6 @@ class _$_CreateAccountState extends _CreateAccountState {
             (identical(other.image, image) || other.image == image) &&
             (identical(other.userName, userName) ||
                 other.userName == userName) &&
-            (identical(other.network, network) || other.network == network) &&
             (identical(other.userAccount, userAccount) ||
                 other.userAccount == userAccount) &&
             (identical(other.command, command) || other.command == command) &&
@@ -854,7 +837,6 @@ class _$_CreateAccountState extends _CreateAccountState {
       pageState,
       image,
       userName,
-      network,
       userAccount,
       command,
       const DeepCollectionEquality().hash(_userAccountRequirements));
@@ -872,7 +854,6 @@ abstract class _CreateAccountState extends EditAccountState {
           {final PageState pageState,
           final XFile? image,
           required final String userName,
-          required final Network network,
           final String? userAccount,
           final PageCommand? command,
           final List<UserAccountRequirement> userAccountRequirements}) =
@@ -885,8 +866,6 @@ abstract class _CreateAccountState extends EditAccountState {
   XFile? get image;
   @override
   String get userName;
-  @override
-  Network get network;
   @override
   String? get userAccount;
   @override

--- a/lib/ui/onboarding/edit_account/interactor/edit_account_state.dart
+++ b/lib/ui/onboarding/edit_account/interactor/edit_account_state.dart
@@ -8,7 +8,6 @@ class EditAccountState with _$EditAccountState {
     @Default(PageState.initial) PageState pageState,
     XFile? image,
     required String userName,
-    required Network network,
     String? userAccount,
     PageCommand? command,
     @Default([]) List<UserAccountRequirement> userAccountRequirements,


### PR DESCRIPTION
Why

Changing the parameters to static create account bloc to include network caused an error in onboarding - onboarding was broken.

Fix

Remove network parameter from views and state, and retrieve it from the deep link bloc - we also retrieve the onboarding secret from there, so this makes sense.