### PR TITLE
Bugfix/loading animation layout fix

### DIFF
--- a/ios/Runner/Base.lproj/LaunchScreen.storyboard
+++ b/ios/Runner/Base.lproj/LaunchScreen.storyboard
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -14,12 +16,14 @@
                         <viewControllerLayoutGuide type="bottom" id="xbc-2k-c8Z"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="LaunchImage" translatesAutoresizingMaskIntoConstraints="NO" id="YRO-k0-Ey4">
+                                <rect key="frame" x="196.33333333333334" y="426" width="0.33333333333334281" height="0.33333333333331439"/>
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" red="0.43529411764705883" green="0.6470588235294118" blue="0.97254901960784312" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
                             <constraint firstItem="YRO-k0-Ey4" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="1a2-6s-vTC"/>
                             <constraint firstItem="YRO-k0-Ey4" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="4X2-HB-R7a"/>
@@ -28,10 +32,10 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="53" y="375"/>
+            <point key="canvasLocation" x="80.916030534351137" y="264.08450704225356"/>
         </scene>
     </scenes>
     <resources>
-        <image name="LaunchImage" width="168" height="185"/>
+        <image name="LaunchImage" width="0.3333333432674408" height="0.3333333432674408"/>
     </resources>
 </document>

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -189,7 +189,7 @@ class HyphaAppView extends StatelessWidget {
             theme: HyphaTheme.lightTheme,
             themeMode: state.themeMode,
             navigatorObservers: <NavigatorObserver>[GetIt.I.get<FirebaseAnalyticsService>().firebaseObserver],
-            home: const SplashPage(),
+            home: const SizedBox.shrink(),
           );
         },
       ),

--- a/lib/ui/blocs/authentication/authentication_bloc.freezed.dart
+++ b/lib/ui/blocs/authentication/authentication_bloc.freezed.dart
@@ -1175,7 +1175,7 @@ class __$$_AuthenticationStateCopyWithImpl<$Res>
 
 class _$_AuthenticationState implements _AuthenticationState {
   const _$_AuthenticationState(
-      {this.authStatus = const UnAuthenticated(),
+      {this.authStatus = const Unknown(),
       this.userProfileData,
       this.userAuthData});
 

--- a/lib/ui/blocs/authentication/authentication_state.dart
+++ b/lib/ui/blocs/authentication/authentication_state.dart
@@ -3,7 +3,7 @@ part of 'authentication_bloc.dart';
 @freezed
 class AuthenticationState with _$AuthenticationState {
   const factory AuthenticationState({
-    @Default(UnAuthenticated()) AuthenticationStatus authStatus,
+    @Default(Unknown()) AuthenticationStatus authStatus,
     UserProfileData? userProfileData,
     UserAuthData? userAuthData,
   }) = _AuthenticationState;

--- a/lib/ui/splash/splash_page.dart
+++ b/lib/ui/splash/splash_page.dart
@@ -33,31 +33,29 @@ class _SplashPageState extends State<SplashPage> with TickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      extendBodyBehindAppBar: true,
-      body: Lottie.asset(
-        fit: BoxFit.fill,
-        'assets/animations/hypha_splash.json',
-        controller: _controller,
-        height: MediaQuery.of(context).size.height * 1,
-        width: MediaQuery.of(context).size.width * 1,
-        animate: true,
-        onLoaded: (composition) {
-          _controller
-            ..duration = composition.duration
-            ..forward().whenComplete(() {
-              final userAuthData = GetIt.I.get<AuthRepository>().currentAuthStatus;
-              if (userAuthData is Authenticated) {
-                if (Get.currentRoute != '/HyphaBottomNavigation') {
-                  Get.offAll(() => const HyphaBottomNavigation());
-                }
-              } else {
-                if (Get.currentRoute != '/OnboardingPage') {
-                  Get.offAll(() => const OnboardingPage());
-                }
-              }
-            });
-        },
-      ),
-    );
+        extendBodyBehindAppBar: true,
+        body: Container(
+          height: MediaQuery.of(context).size.height * 1,
+          width: MediaQuery.of(context).size.width * 1,
+          child: FittedBox(
+              fit: BoxFit.cover,
+              child: Lottie.asset('assets/animations/hypha_splash.json', controller: _controller, animate: true,
+                  onLoaded: (composition) {
+                _controller
+                  ..duration = composition.duration
+                  ..forward().whenComplete(() {
+                    final userAuthData = GetIt.I.get<AuthRepository>().currentAuthStatus;
+                    if (userAuthData is Authenticated) {
+                      if (Get.currentRoute != '/HyphaBottomNavigation') {
+                        Get.offAll(() => const HyphaBottomNavigation());
+                      }
+                    } else {
+                      if (Get.currentRoute != '/OnboardingPage') {
+                        Get.offAll(() => const OnboardingPage());
+                      }
+                    }
+                  });
+              })),
+        ));
   }
 }


### PR DESCRIPTION
Launch animation updates

- Launch screen background in iOS matches animation (instead of white and empty). Note: This is the native, static, iOS launch screen - it doesn't do animations, and it's outside of flutter code base. 
- Animation uses cover fit so it is always centered, always covers the entire screen, and does not get stretched

Still do do @gguijarro-c-chwy  : 
- Because the home screen also has a "SplashPage" which appears for a brief moment, the initial animation looks like it's off center and then moving into center. We are starting the animation twice. Not sure what the best solution is there - but also not sure why we have 3 places where splashpage is invoked - seems there should just be one?!
- Android - does it also have a native/static launch screen that should match the color?

I didn't put a hypha logo on the launch screen because centering might then be an issue and it would maybe interfere with the animation. 