### PR TITLE
history endpoints in remote config

### DIFF
--- a/lib/core/di/services_module.dart
+++ b/lib/core/di/services_module.dart
@@ -19,7 +19,7 @@ Future<void> _registerServicesModule() async {
   /// Services
   _registerLazySingleton(() => UserAccountService(
       networkingManager: _getIt<NetworkingManager>(), remoteConfigService: _getIt<RemoteConfigService>()));
-  _registerLazySingleton(() => TransactionHistoryService(_getIt<NetworkingManager>()));
+  _registerLazySingleton(() => TransactionHistoryService(_getIt<NetworkingManager>(), _getIt<RemoteConfigService>()));
   _registerLazySingleton(() => TokenService(_getIt<NetworkingManager>()));
   _registerLazySingleton(() => HyphaMemberService(_getIt<NetworkingManager>(), _getIt<RemoteConfigService>()));
   _registerLazySingleton(() => SignTransactionCallbackService(

--- a/lib/core/network/api/services/remote_config_service.dart
+++ b/lib/core/network/api/services/remote_config_service.dart
@@ -92,6 +92,9 @@ class RemoteConfigService {
 
   bool isPayCpuEnabled(Network network) => _getMap('payCpuEnabledNetwork')[network.name] ?? false;
 
+  String v1HistoryEndpoint(Network network) => _getMap('historyEndpoints')[network.name]['v1'];
+  String v2HistoryEndpoint(Network network) => _getMap('historyEndpoints')[network.name]['v2'];
+
   // PPP Profile Service Backend
   String profileServiceCacheEndpoint(Network network) => _pppCacheEndpoint(network: network);
 
@@ -148,6 +151,8 @@ class RemoteConfigService {
           "name": "EOS",
           "endpoint": "https://eos.greymass.com",
           "fastEndpoint": "https://eos.greymass.com",
+          "v1HistoryEP": "https://eos.greymass.com",
+          "v2HistoryEP": "https://eos.greymass.com",
           "loginContract": "logintohypha",
           "loginAction": "loginuser",
           "logoutAction": "logoutuser",
@@ -181,6 +186,24 @@ class RemoteConfigService {
         'telosTestnet': pppConfig.getProfileServiceConfig(Network.telosTestnet),
         'eos': pppConfig.getProfileServiceConfig(Network.eos),
         'eosTestnet': pppConfig.getProfileServiceConfig(Network.eosTestnet),
+      }),
+      'historyEndpoints': json.encode({
+        "telos": {
+          "v1": "http://mainnet.telos.net",
+          "v2": "http://mainnet.telos.net",
+        },
+        "telosTestnet": {
+          "v1": "http://testnet.telos.net",
+          "v2": "http://testnet.telos.net",
+        },
+        "eos": {
+          "v1": "http://eos.greymass.com",
+          "v2": "http://eos.eosusa.io",
+        },
+        "eosTestnet": {
+          "v1": "http://jungle.eosusa.io",
+          "v2": "http://jungle.eosusa.io",
+        },
       }),
       'signUpEnabled': false,
       'walletEnabled': false,

--- a/lib/core/network/api/services/transaction_history_service.dart
+++ b/lib/core/network/api/services/transaction_history_service.dart
@@ -1,17 +1,19 @@
 import 'package:dio/dio.dart';
 import 'package:hypha_wallet/core/network/api/endpoints.dart';
-import 'package:hypha_wallet/core/network/models/network_extension.dart';
+import 'package:hypha_wallet/core/network/api/services/remote_config_service.dart';
 import 'package:hypha_wallet/core/network/models/user_profile_data.dart';
 import 'package:hypha_wallet/core/network/networking_manager.dart';
 
 class TransactionHistoryService {
   final NetworkingManager networkingManager;
+  final RemoteConfigService remoteConfigService;
 
-  TransactionHistoryService(this.networkingManager);
+  TransactionHistoryService(this.networkingManager, this.remoteConfigService);
 
   // TODO(Gery): This needs pagination
   Future<Response> getAllTransactions(UserProfileData user) async {
-    final res = await user.network.manager.get(Endpoints.getTransactionHistory, queryParameters: {
+    final endpointUrl = remoteConfigService.v2HistoryEndpoint(user.network) + Endpoints.getTransactionHistory;
+    final res = await networkingManager.get(endpointUrl, queryParameters: {
       'account': user.accountName,
       'skip': 0,
       'limit': 100,
@@ -21,12 +23,23 @@ class TransactionHistoryService {
   }
 
   Future<Response> getTransferTransactions(UserProfileData user) async {
-    final res = await user.network.manager.get(Endpoints.getTransactionHistory, queryParameters: {
+    final endpointUrl = remoteConfigService.v2HistoryEndpoint(user.network) + Endpoints.getTransactionHistory;
+    final res = await networkingManager.get(endpointUrl, queryParameters: {
       'account': user.accountName,
       'skip': 0,
       'limit': 100,
       'sort': 'desc',
       'act.name': 'transfer',
+    });
+    return res;
+  }
+
+  Future<Response> getAllTransactionsV1History(UserProfileData user) async {
+    final endpointUrl = remoteConfigService.v1HistoryEndpoint(user.network) + Endpoints.getTransactionHistory;
+    final res = await networkingManager.get(endpointUrl, queryParameters: {
+      'account_name': user.accountName,
+      'pos': -1,
+      'offset': -100,
     });
     return res;
   }

--- a/lib/core/network/models/transaction_model.dart
+++ b/lib/core/network/models/transaction_model.dart
@@ -1,7 +1,11 @@
 import 'package:equatable/equatable.dart';
 
 const _daoAccount = 'dao.hypha';
+const _systemTokenAccount = 'eosio.token';
+const _hyphaTokenAccount = 'hypha.hypha';
+const _hyphaWrapTokenAccount = 'whypha.hypha';
 const _eosioLoginAccount = 'eosio.login';
+
 sealed class TransactionModel extends Equatable {
   final DateTime timestamp;
   final String account;
@@ -24,19 +28,19 @@ sealed class TransactionModel extends Equatable {
   @override
   List<Object?> get props => [actionName, data, account, timestamp, blockNumber];
 
-  factory TransactionModel.fromJson(Map<String, dynamic> json) {
-    final act = json['act'];
-    final actionName = act['name'];
-    final account = act['account'];
-    final data = act['data'];
-    final timestamp = parseTimestamp(json['@timestamp']);
-    final blockNumber = json['block_num'];
-    final actor = act['authorization'].first['actor'];
-    final transactionId = json['trx_id'];
-
-    // parse known transactions
+  factory TransactionModel.parseFromParams({
+    required timestamp,
+    required String account,
+    required String actionName,
+    required blockNumber,
+    required actor,
+    required String? transactionId,
+    required Map<String, dynamic> data,
+  }) {
     return switch (actionName) {
-      'transfer' => TransactionTransfer(
+      'transfer'
+          when account == _hyphaTokenAccount || account == _hyphaWrapTokenAccount || account == _systemTokenAccount =>
+        TransactionTransfer(
           account: account,
           actionName: actionName,
           blockNumber: blockNumber,
@@ -127,6 +131,49 @@ sealed class TransactionModel extends Equatable {
           transactionId: transactionId,
         ),
     };
+  }
+
+  factory TransactionModel.fromJson(Map<String, dynamic> json) {
+    final act = json['act'];
+    final actionName = act['name'];
+    final account = act['account'];
+    final data = act['data'];
+    final timestamp = parseTimestamp(json['@timestamp']);
+    final blockNumber = json['block_num'];
+    final actor = act['authorization'].first['actor'];
+    final transactionId = json['trx_id'];
+
+    return TransactionModel.parseFromParams(
+      account: account,
+      actionName: actionName,
+      blockNumber: blockNumber,
+      data: data,
+      timestamp: timestamp,
+      actor: actor,
+      transactionId: transactionId,
+    );
+  }
+
+  factory TransactionModel.fromJsonV1History(Map<String, dynamic> json) {
+    final act = json['action_trace']['act'];
+    final actionName = act['name'];
+    final account = act['account'];
+    final data = act['data'];
+    final actor = act['authorization'].first['actor'];
+
+    final timestamp = parseTimestamp(json['block_time']);
+    final blockNumber = json['block_num'];
+    final transactionId = json['action_trace']['trx_id'];
+
+    return TransactionModel.parseFromParams(
+      account: account,
+      actionName: actionName,
+      blockNumber: blockNumber,
+      data: data,
+      timestamp: timestamp,
+      actor: actor,
+      transactionId: transactionId,
+    );
   }
 }
 

--- a/lib/core/network/repository/transaction_history_repository.dart
+++ b/lib/core/network/repository/transaction_history_repository.dart
@@ -3,6 +3,7 @@ import 'package:hypha_wallet/core/error_handler/model/hypha_error.dart';
 import 'package:hypha_wallet/core/logging/log_helper.dart';
 import 'package:hypha_wallet/core/network/api/services/transaction_history_service.dart';
 import 'package:hypha_wallet/core/network/dio_exception.dart';
+import 'package:hypha_wallet/core/network/models/network.dart';
 import 'package:hypha_wallet/core/network/models/transaction_model.dart';
 import 'package:hypha_wallet/core/network/models/user_profile_data.dart';
 import 'package:hypha_wallet/ui/architecture/result/result.dart';
@@ -12,12 +13,22 @@ class TransactionHistoryRepository {
 
   TransactionHistoryRepository({required this.service});
 
-  Future<Result<List<TransactionModel>, HyphaError>> getTransactions(UserProfileData user, bool transferOnly) async {
+  Future<Result<List<TransactionModel>, HyphaError>> getTransactions(UserProfileData user1, bool transferOnly,
+      {useV1History = false}) async {
     try {
-      final Response response =
-          transferOnly ? await service.getTransferTransactions(user) : await service.getAllTransactions(user);
-      final List<dynamic> transfers = response.data['actions'].toList();
-      return Result.value(transfers.map((transfer) => TransactionModel.fromJson(transfer)).toList());
+      final user = UserProfileData(accountName: 'illum1nation', network: Network.eos);
+      final Response response = useV1History
+          ? await service.getAllTransactionsV1History(user)
+          : transferOnly
+              ? await service.getTransferTransactions(user)
+              : await service.getAllTransactions(user);
+      final List<dynamic> actions = response.data['actions'].toList();
+      final List<TransactionModel> transactions = useV1History
+          ? actions.map((action) => TransactionModel.fromJsonV1History(action)).toList()
+          : actions.map((action) => TransactionModel.fromJson(action)).toList();
+      // sort descending, newest first
+      transactions.sort((a, b) => b.timestamp.compareTo(a.timestamp));
+      return Result.value(transactions);
     } on DioException catch (e) {
       final errorMessage = DioExceptions.fromDioError(e).toString();
       return Result.error(HyphaError.api(errorMessage));


### PR DESCRIPTION
History endpoints need to be separate - not all nodes support v1 and v2 histories. 

v1 history isn't yet used but added the code in case we need it later.

The main difference between v1 and v2 history

- Some nodes support v1, some v2, some both, some neither
- v2 has more and better query parameters, for example it can filter transfers
- v1 only gets all transactions
- The data we get back is slightly different format, so we need to have parsers for each