### PR TITLE
Bugfix/handle transaction error

### DIFF
--- a/lib/ui/sign_transaction/usecases/sign_transaction_use_case.dart
+++ b/lib/ui/sign_transaction/usecases/sign_transaction_use_case.dart
@@ -19,6 +19,10 @@ class SignTransactionUseCase extends InputUseCase<HResult.Result<String, HyphaEr
   @override
   Future<HResult.Result<String, HyphaError>> run(SignTransactionInput input) async {
     final userData = _authRepository.authDataOrCrash;
+    if (input.eOSTransaction.network != userData.userProfileData.network) {
+      return HResult.Result.error(HyphaError.api(
+          'Wrong network. Transaction on ${input.eOSTransaction.network} cannot be signed by user on ${userData.userProfileData.network}'));
+    }
     final Result<dynamic> result;
     try {
       result = await eosService.sendTransaction(


### PR DESCRIPTION
Bug: Wrong network sign causes endless spinning

Bugfix 1: Handle any exceptions -> show error, don't spin endlessly

Bugfix 2: Handle network mismatch to fail fast -> Show error

I tested both cases by being logged in with an EOS account and signing on Telos (or trying to)