### PR TITLE
Update account import

### DIFF
--- a/lib/core/crypto/eosdart/src/client.dart
+++ b/lib/core/crypto/eosdart/src/client.dart
@@ -203,12 +203,15 @@ class EOSClient extends NetworkingManager {
     });
   }
 
-  /// Get Key Accounts
-  Future<Result<AccountNames>> getKeyAccounts(String pubKey) async {
+  /// Get accounts by key - uses /chain/get_accounts_by_authorizers
+  Future<Result<AccountNames>> getAccountsByKey(String pubKey) async {
     try {
-      return Result.capture(
-          _post('/history/get_key_accounts', {'public_key': pubKey}).then((dio.Response accountNames) {
-        return AccountNames.fromJson(accountNames.data as Map<String, dynamic>);
+      return Result.capture(_post('/chain/get_accounts_by_authorizers', {
+        'accounts': [],
+        'keys': [pubKey]
+      }).then((dio.Response response) {
+        final List<String> accountNames = List.from(response.data['accounts'].map((e) => e['account_name']));
+        return AccountNames(accountNames.toSet().toList());
       }));
     } catch (e) {
       LogHelper.e(e.toString());

--- a/lib/core/logging/log_helper.dart
+++ b/lib/core/logging/log_helper.dart
@@ -1,6 +1,5 @@
 import 'package:fimber/fimber.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
-import 'package:flutter/foundation.dart';
 
 const kLogQuietMode = false;
 const kIsDebugNetworking = true;
@@ -36,6 +35,8 @@ class LogHelper {
   static void e(String message, {dynamic error, StackTrace? stacktrace}) {
     Fimber.e(message, ex: error, stacktrace: stacktrace);
     FirebaseCrashlytics.instance.log('Error message $message \nStackTrace: $stacktrace');
-    if (error != null && kDebugMode) throw error;
+    // Nik: I commented out below. A log should never throw an error!
+    // It should log things. Not throw errors.
+    // if (error != null && kDebugMode) throw error;
   }
 }

--- a/lib/core/network/api/services/remote_config_service.dart
+++ b/lib/core/network/api/services/remote_config_service.dart
@@ -161,8 +161,8 @@ class RemoteConfigService {
         },
         "eosTestnet": {
           "name": "Jungle4 Testnet",
-          "endpoint": "https://jungle4.dfuse.eosnation.io",
-          "fastEndpoint": "https://jungle4.dfuse.eosnation.io",
+          "endpoint": "http://jungle.eosusa.io/",
+          "fastEndpoint": "http://jungle.eosusa.io/",
           "loginContract": "logintohypha",
           "loginAction": "loginuser",
           "logoutAction": "logoutuser",
@@ -207,6 +207,7 @@ class RemoteConfigService {
       'walletEnabled': false,
     });
     FirebaseRemoteConfig.instance.onConfigUpdated.listen((event) async {
+      // Side note: This does not seem to work reliably on simulator but it works in the app.
       await FirebaseRemoteConfig.instance.activate();
     });
   }

--- a/lib/core/network/repository/profile_repository.dart
+++ b/lib/core/network/repository/profile_repository.dart
@@ -22,7 +22,7 @@ class ProfileService {
         final map = Map<String, dynamic>.from(response.data);
         return Result.value(ProfileData.fromJson(map, user.network, []));
       } else {
-        LogHelper.i('get profile status error');
+        LogHelper.i('get profile error status code: ${response.statusMessage}');
         return Result.error(HyphaError(type: HyphaErrorType.api, message: 'server error ${response.statusMessage}'));
       }
     } catch (error, stackTrace) {

--- a/lib/core/network/repository/profile_repository.dart
+++ b/lib/core/network/repository/profile_repository.dart
@@ -22,12 +22,13 @@ class ProfileService {
         final map = Map<String, dynamic>.from(response.data);
         return Result.value(ProfileData.fromJson(map, user.network, []));
       } else {
-        LogHelper.e('get profile status error', stacktrace: StackTrace.current);
+        LogHelper.i('get profile status error');
         return Result.error(HyphaError(type: HyphaErrorType.api, message: 'server error ${response.statusMessage}'));
       }
     } catch (error, stackTrace) {
       // note: 500 status on get throws an error
-      LogHelper.e('get profile error', stacktrace: stackTrace, error: error);
+      // this happens when the profile doesn't exist, which is valid
+      LogHelper.i('get profile error', stacktrace: stackTrace, error: error);
       return Result.error(HyphaError(type: HyphaErrorType.api, message: 'server error $error'));
     }
   }

--- a/lib/core/network/repository/transaction_history_repository.dart
+++ b/lib/core/network/repository/transaction_history_repository.dart
@@ -3,7 +3,6 @@ import 'package:hypha_wallet/core/error_handler/model/hypha_error.dart';
 import 'package:hypha_wallet/core/logging/log_helper.dart';
 import 'package:hypha_wallet/core/network/api/services/transaction_history_service.dart';
 import 'package:hypha_wallet/core/network/dio_exception.dart';
-import 'package:hypha_wallet/core/network/models/network.dart';
 import 'package:hypha_wallet/core/network/models/transaction_model.dart';
 import 'package:hypha_wallet/core/network/models/user_profile_data.dart';
 import 'package:hypha_wallet/ui/architecture/result/result.dart';

--- a/lib/ui/home_page/components/scanner_widget.dart
+++ b/lib/ui/home_page/components/scanner_widget.dart
@@ -99,7 +99,7 @@ class _ScannerWidgetState extends State<ScannerWidget> {
                                           ),
                                         );
                                   } else {
-                                    final String code = barcodes.first!.rawValue!;
+                                    final String code = barcodes.first.rawValue!;
                                     LogHelper.d('Barcode found! $code');
                                     hideScanner();
                                     context.read<HomeBloc>().add(HomeEvent.onQRCodeScanned(code));

--- a/lib/ui/onboarding/import_account/usecases/find_account_use_case.dart
+++ b/lib/ui/onboarding/import_account/usecases/find_account_use_case.dart
@@ -40,10 +40,10 @@ class FindAccountsUseCase extends InputUseCase<Result<Iterable<UserProfileData>,
     );
 
     final results = await Future.wait([
-      eosClient.getKeyAccounts(input),
-      telosClient.getKeyAccounts(input),
-      telosTestnetClient.getKeyAccounts(input),
-      eosTestnetClient.getKeyAccounts(input)
+      eosClient.getAccountsByKey(input),
+      telosClient.getAccountsByKey(input),
+      telosTestnetClient.getAccountsByKey(input),
+      eosTestnetClient.getAccountsByKey(input)
     ]);
     final eosResult = results[0];
     final telosResult = results[1];


### PR DESCRIPTION
The history plugin is officially deprecated and many nodes don't support it

This changes our account import to use a different call in the chain API - should be more stable. 

A couple of changes

- more widely supported way to import accounts - does not rely on the deprecated history plugin
- profile errors are not errors, just means no profile
- Loggers shall not throw errors that's just weird


Note: The new call can return accounts multiple times, when an account has owner and active keys that are the same, so it needs to de-duplicate the list. 
