### PR TITLE
Feature/pay cpu 2 0

### DIFF
--- a/lib/core/crypto/eosdart/src/serialize.dart
+++ b/lib/core/crypto/eosdart/src/serialize.dart
@@ -471,7 +471,7 @@ int checkRange(int orig, int converted) {
 }
 
 DateTime checkDateParse(String date) {
-  var result = DateTime.parse(date + 'Z');
+  var result = DateTime.parse(date.endsWith('Z') ? date : date + 'Z');
   return result;
 }
 

--- a/lib/core/network/api/eos_service.dart
+++ b/lib/core/network/api/eos_service.dart
@@ -8,8 +8,10 @@ import 'package:hypha_wallet/core/crypto/seeds_esr/eos_transaction.dart';
 import 'package:hypha_wallet/core/local/models/user_auth_data.dart';
 import 'package:hypha_wallet/core/local/services/secure_storage_service.dart';
 import 'package:hypha_wallet/core/logging/log_helper.dart';
+import 'package:hypha_wallet/core/network/api/endpoints.dart';
 import 'package:hypha_wallet/core/network/api/services/remote_config_service.dart';
 import 'package:hypha_wallet/core/network/models/network.dart';
+import 'package:hypha_wallet/core/network/models/network_extension.dart';
 import 'package:hypha_wallet/core/network/models/token_value.dart';
 import 'package:hypha_wallet/core/network/models/user_profile_data.dart';
 
@@ -223,6 +225,17 @@ class EOSService {
     print('action to be proposed: $action');
 
     return action;
+  }
+
+  Future<Result<Account>> getAccount(String accountName, Network network) async {
+    final requestBody = {'account_name': accountName};
+    try {
+      final res = await network.manager.post(Endpoints.getAccount, data: requestBody);
+      return Result.value(Account.fromJson(res.data));
+    } catch (error) {
+      LogHelper.e('getAccount Error', error: error);
+      return Result.error('getAccount Error: $error');
+    }
   }
 }
 

--- a/lib/core/network/api/services/remote_config_service.dart
+++ b/lib/core/network/api/services/remote_config_service.dart
@@ -89,6 +89,8 @@ class RemoteConfigService {
   bool get isSignUpEnabled => FirebaseRemoteConfig.instance.getBool('signUpEnabled');
   String get signUpLinkUrl => FirebaseRemoteConfig.instance.getString('signUpLinkUrl');
 
+  int get newAccountFreshnessHours => FirebaseRemoteConfig.instance.getInt('newAccountFreshnessHours');
+
   bool get isWalletEnabled => FirebaseRemoteConfig.instance.getBool('walletEnabled');
 
   bool isPayCpuEnabled(Network network) => _getMap('payCpuEnabledNetwork')[network.name] ?? false;
@@ -207,6 +209,8 @@ class RemoteConfigService {
       'signUpEnabled': true,
       "signUpLinkUrl": "https://dao.hypha.earth/hypha/login",
       'walletEnabled': false,
+      'newAccountFreshnessHours': 48,
+      'payCpuEnabledNetwork': json.encode({"telos": false, "telosTestnet": true, "eos": true, "eosTestnet": true})
     });
     FirebaseRemoteConfig.instance.onConfigUpdated.listen((event) async {
       // Side note: This does not seem to work reliably on simulator but it works in the app.


### PR DESCRIPTION
There's a new rule - we can pay for accounts that we created and that are less than 48 hours old

This allows EOS users to onboard in peace without running into CPU / NET problems. 