### PR TITLE
fix QR deserialization for negative big nums

### DIFF
--- a/lib/core/crypto/eosdart/src/numeric.dart
+++ b/lib/core/crypto/eosdart/src/numeric.dart
@@ -121,7 +121,7 @@ String binaryToDecimal(Uint8List bignum, {minDigits = 1}) {
 /// @param minDigits 0-pad result to this many digits
 String signedBinaryToDecimal(Uint8List bignum, {int minDigits = 1}) {
   if (isNegative(bignum)) {
-    var x = Uint8List.fromList(bignum.getRange(0, 0).toList());
+    var x = Uint8List.fromList(bignum.getRange(0, bignum.length).toList());
     negate(x);
     return '-' + binaryToDecimal(x, minDigits: minDigits);
   }


### PR DESCRIPTION
bugfix at #150 deserializes all neg numbers as "-0". This PR fixes the shallow copy operation so that results are correct.

![image](https://github.com/hypha-dao/hypha_wallet/assets/2141014/8520e586-d590-4b0b-b7cc-ffe55aa1e18c)
![image](https://github.com/hypha-dao/hypha_wallet/assets/2141014/2da570ce-56d2-48da-af7b-4a1975feb7c6)

backported from Localscale wallet

Note: upstream PR at https://github.com/primes-network/eosdart/pull/47
