### PR TITLE
Fix for DEV-1260 - open login page in external window

### DIFF
--- a/lib/ui/onboarding/onboarding_page.dart
+++ b/lib/ui/onboarding/onboarding_page.dart
@@ -19,7 +19,10 @@ class OnboardingPage extends StatelessWidget {
   Widget build(BuildContext context) {
     Future<void> _launchUrl() async {
       final _url = GetIt.I.get<RemoteConfigService>().signUpLinkUrl;
-      if (!await launchUrl(Uri.parse(_url))) {
+      if (!await launchUrl(
+        Uri.parse(_url),
+        mode: LaunchMode.externalApplication,
+      )) {
         ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
           content: Text('Error Launching URL. Please visit dao.hypha.earth'),
         ));


### PR DESCRIPTION
Discussion:

On sign up, we used an internal app browser window.

Deep links don't work at all in Android in the internal browser window - it leads to an error page. 

Deep links work on iOS but the app would not close the browser window, so users had to hit "Done"

Fix:

We use an external browser, for the normal onboarding flow. 

This is the safest fix since opening the deep link does the right thing on all platforms, and we don't need to worry about app state either. 