### PR TITLE
Back to in app browser

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -24,6 +24,7 @@ import 'package:hypha_wallet/ui/settings/save_words_page.dart';
 import 'package:hypha_wallet/ui/shared/ui_constants.dart';
 import 'package:hypha_wallet/ui/sign_transaction/sign_transaction_page.dart';
 import 'package:hypha_wallet/ui/splash/splash_page.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class HyphaApp extends StatelessWidget {
   const HyphaApp({super.key});
@@ -92,7 +93,12 @@ class HyphaAppView extends StatelessWidget {
           listenWhen: (previous, current) => previous.command != current.command,
           listener: (context, state) {
             state.command?.when(
-              navigateToCreateAccount: () => Get.Get.offAll(() => const OnboardingPageWithLink()),
+              navigateToCreateAccount: () async {
+                /// Note: In the case there is an in app web view, close it.
+                await closeInAppWebView();
+                // ignore: unawaited_futures
+                Get.Get.offAll(() => const OnboardingPageWithLink());
+              },
               navigateToSignTransaction: (ScanQrCodeResultData data) {
                 _showSignTransactionBottomSheet(data);
               },
@@ -228,7 +234,7 @@ class HyphaAppView extends StatelessWidget {
 
   void _showJoinDaoRationale(InviteLinkData inviteLinkData, BuildContext context) {
     Get.Get.bottomSheet(
-        JoinDaoRationaleBottomSheet(inviteLinkData: inviteLinkData),
+      JoinDaoRationaleBottomSheet(inviteLinkData: inviteLinkData),
       isScrollControlled: true,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(30)),

--- a/lib/ui/onboarding/onboarding_page.dart
+++ b/lib/ui/onboarding/onboarding_page.dart
@@ -21,7 +21,7 @@ class OnboardingPage extends StatelessWidget {
       final _url = GetIt.I.get<RemoteConfigService>().signUpLinkUrl;
       if (!await launchUrl(
         Uri.parse(_url),
-        mode: LaunchMode.externalApplication,
+        mode: LaunchMode.inAppWebView,
       )) {
         ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
           content: Text('Error Launching URL. Please visit dao.hypha.earth'),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.0+57
+version: 1.2.1+58
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
Close the in app browser on onboarding link detected

This reverts a previous change where we changed to external browser - Apple App Review does not like opening external browsers, it's against the rules. 

So we now use in app and deployed a different solution to the original problem. 